### PR TITLE
filter earthquake data

### DIFF
--- a/src/lib/eurasia_earthquakes.csv
+++ b/src/lib/eurasia_earthquakes.csv
@@ -1,456 +1,844 @@
 time,latitude,longitude,depth,mag,magType,nst,gap,dmin,rms,net,id,updated,place,type,horizontalError,depthError,magError,magNst,status,locationSource,magSource
-2023-02-17T09:11:40.742Z,45.086,23.0675,10,4.5,mb,25,129,1.139,0.65,us,us6000jpju,2023-02-17T09:30:39.040Z,"3 km SSW of Valea Mare, Romania",earthquake,2.53,1.903,0.156,12,reviewed,us,us
-2023-02-17T01:46:31.312Z,26.4738,128.7992,13.336,5.2,mww,85,50,0.594,0.97,us,us6000jpi5,2023-02-17T03:29:11.150Z,"82 km E of Nago, Japan",earthquake,6.69,3.944,0.071,19,reviewed,us,us
-2023-02-17T01:29:24.699Z,26.0429,123.5068,271.161,4.3,mb,41,82,1.632,0.65,us,us6000jpi3,2023-02-17T02:55:04.040Z,"northeast of Taiwan",earthquake,8.78,7.666,0.098,29,reviewed,us,us
-2023-02-17T01:22:50.098Z,23.9297,121.5086,16.822,4.7,mb,28,96,0.255,0.66,us,us6000jpi1,2023-02-17T08:49:24.344Z,"11 km WSW of Hualien City, Taiwan",earthquake,2.54,1.251,0.099,31,reviewed,us,us
-2023-02-17T00:35:57.301Z,39.1579,40.1603,2.075,4.4,mb,59,46,0.898,1.14,us,us6000jphu,2023-02-17T00:49:28.040Z,"10 km SE of Yayladere, Turkey",earthquake,1.99,5.371,0.075,52,reviewed,us,us
-2023-02-16T19:47:49.578Z,36.2011,35.8284,10,5.2,mww,118,59,1.474,1.22,us,us6000jpff,2023-02-17T07:05:35.084Z,"19 km WNW of Uzunba?, Turkey",earthquake,5.25,1.824,0.052,35,reviewed,us,us
-2023-02-16T18:17:20.673Z,37.3072,70.5356,57.108,4.7,mb,119,28,2.384,0.62,us,us6000jpex,2023-02-16T19:45:15.442Z,"21 km N of Fayzabad, Afghanistan",earthquake,6.39,6.932,0.056,103,reviewed,us,us
-2023-02-16T16:38:32.216Z,37.9225,37.5073,10,4.1,mb,34,83,0.637,0.48,us,us6000jpee,2023-02-16T18:19:48.040Z,"7 km SE of Nurhak, Turkey",earthquake,1.7,1.928,0.302,3,reviewed,us,us
-2023-02-16T14:45:42.064Z,38.2035,37.8096,10,4.5,mb,31,71,0.979,1.15,us,us6000jpdx,2023-02-16T15:00:52.040Z,"14 km NNW of Do?an?ehir, Turkey",earthquake,2.9,1.91,0.108,25,reviewed,us,us
-2023-02-16T11:16:23.422Z,35.9277,35.768,10,4.8,mww,187,46,1.7,0.79,us,us6000jpd5,2023-02-16T23:32:50.254Z,"26 km W of Yaylada??, Turkey",earthquake,3.58,1.771,0.098,10,reviewed,us,us
-2023-02-16T09:47:45.901Z,44.9868,14.706,10,4.8,mb,109,14,0.981,0.57,us,us6000jpbt,2023-02-17T07:16:41.548Z,"4 km WNW of Baška, Croatia",earthquake,2.9,1.825,0.047,139,reviewed,us,us
-2023-02-16T05:18:57.585Z,38.0947,38.5702,16.14,4.3,mb,53,66,0.682,0.99,us,us6000jpaw,2023-02-16T06:07:15.040Z,"7 km NNW of Sincik, Turkey",earthquake,3.69,5.566,0.101,28,reviewed,us,us
-2023-02-16T03:56:28.849Z,25.0868,91.743,61.857,4.3,mb,25,166,5.262,0.63,us,us6000jpaj,2023-02-17T05:48:45.091Z,"9 km NE of Chh?tak, Bangladesh",earthquake,10.49,10.546,0.142,15,reviewed,us,us
-2023-02-16T02:35:41.476Z,51.8265,105.3127,10,4.6,mb,21,90,1.048,0.55,us,us6000jpa8,2023-02-16T17:37:56.032Z,"30 km E of Listvyanka, Russia",earthquake,6.29,1.921,0.172,10,reviewed,us,us
-2023-02-16T01:07:04.795Z,45.0736,23.0978,10,4.4,mb,30,84,1.164,1.03,us,us6000jp9t,2023-02-17T09:11:38.793Z,"2 km WSW of Arcani, Romania",earthquake,4.62,1.938,0.203,7,reviewed,us,us
-2023-02-15T23:43:38.943Z,37.3475,36.8589,13.193,4,mb,22,109,0.33,0.96,us,us6000jp9e,2023-02-16T00:14:04.040Z,"22 km NNE of Nurda??, Turkey",earthquake,3.4,1.75,0.195,7,reviewed,us,us
-2023-02-15T22:25:58.228Z,38.0555,36.6113,5.561,4.1,mb,24,52,0.383,0.68,us,us6000jp8t,2023-02-15T22:43:04.040Z,"10 km ENE of Göksun, Turkey",earthquake,2.98,11.207,0.114,22,reviewed,us,us
-2023-02-15T08:07:01.205Z,54.7502,161.3814,35,4.3,mb,58,124,2.368,1.04,us,us6000jp2c,2023-02-15T10:37:08.040Z,"",earthquake,8.58,1.937,0.079,45,reviewed,us,us
-2023-02-15T07:36:30.670Z,38.0139,36.48,10,4.6,mb,70,56,0.973,0.78,us,us6000jp25,2023-02-15T19:06:02.430Z,"1 km WSW of Göksun, Turkey",earthquake,5.87,1.884,0.094,34,reviewed,us,us
-2023-02-15T06:25:30.425Z,38.0958,36.7171,8.443,4.2,mb,49,53,0.39,0.76,us,us6000jp1e,2023-02-15T07:13:18.040Z,"21 km ENE of Göksun, Turkey",earthquake,5.43,6.469,0.113,22,reviewed,us,us
-2023-02-15T03:09:21.674Z,56.3643,162.9985,37.807,4.9,mb,62,109,4.192,0.46,us,us6000jp0v,2023-02-15T20:18:32.040Z,"35 km ENE of Ust’-Kamchatsk Staryy, Russia",earthquake,8.95,4.41,0.04,195,reviewed,us,us
-2023-02-15T01:32:07.682Z,44.4388,148.9987,35,4.3,mb,41,168,4.611,0.58,us,us6000jp0k,2023-02-15T18:19:59.040Z,"124 km SE of Kuril’sk, Russia",earthquake,13.3,1.957,0.097,30,reviewed,us,us
-2023-02-15T00:06:02.103Z,36.6629,36.5602,10,4.1,mb,40,118,2.257,1.04,us,us6000jp0a,2023-02-15T04:28:50.338Z,"12 km S of A?a?? Karafak?l?, Turkey",earthquake,5.78,1.962,0.112,22,reviewed,us,us
-2023-02-14T23:14:01.639Z,38.5556,37.4549,2.628,4.2,mb,49,65,0.872,0.89,us,us6000jnzr,2023-02-15T01:45:36.040Z,"4 km WNW of Darende, Turkey",earthquake,4.71,4.089,0.108,24,reviewed,us,us
-2023-02-14T15:50:40.851Z,38.0868,37.1649,19.431,4.4,mb,41,102,1.286,0.52,us,us6000jnxk,2023-02-14T16:43:22.040Z,"3 km NW of Ekinözü, Turkey",earthquake,5.02,5.467,0.134,16,reviewed,us,us
-2023-02-14T15:37:30.005Z,36.7207,71.0221,215.506,4.2,mb,44,94,2.509,0.68,us,us6000jnxh,2023-02-14T16:21:37.040Z,"23 km SE of Jurm, Afghanistan",earthquake,8.34,7.507,0.104,26,reviewed,us,us
-2023-02-14T13:44:03.163Z,35.3775,35.3986,10,4.4,mb,38,171,1.744,0.87,us,us6000jnr1,2023-02-14T15:25:21.040Z,"39 km WSW of Latakia, Syria",earthquake,7.65,1.918,0.138,15,reviewed,us,us
+2023-02-16T19:47:49.648Z,36.1764,35.7911,10,5.2,mww,136,59,1.47,0.93,us,us6000jpff,2023-02-17T20:03:45.029Z,"22 km W of Uzunba?, Turkey",earthquake,5.93,0.861,0.052,35,reviewed,us,us
 2023-02-14T13:16:51.072Z,45.1126,23.1781,10,5.6,mww,132,28,1.197,0.4,us,us6000jnqz,2023-02-17T09:15:18.586Z,"2 km NW of Lele?ti, Romania",earthquake,4.85,1.794,0.032,95,reviewed,us,us
-2023-02-14T11:54:11.666Z,35.9037,36.1184,10,4.4,mb,66,114,2.463,0.62,us,us6000jnqt,2023-02-14T15:01:02.040Z,"5 km E of Yaylada??, Turkey",earthquake,4.65,1.782,0.095,32,reviewed,us,us
-2023-02-14T03:08:57.881Z,37.9873,144.4419,10,4.5,mb,44,193,3.831,0.36,us,us6000jnpn,2023-02-15T00:53:29.040Z,"265 km ESE of Kamaishi, Japan",earthquake,10.88,1.946,0.102,28,reviewed,us,us
-2023-02-13T19:20:27.585Z,38.0201,36.4179,4.929,4.8,mb,81,55,0.944,0.74,us,us6000jnmc,2023-02-15T01:50:03.040Z,"6 km W of Göksun, Turkey",earthquake,5.35,4.487,0.058,92,reviewed,us,us
-2023-02-13T18:38:49.462Z,38.9684,92.6628,10,5.1,mb,76,46,10.847,0.85,us,us6000jnm7,2023-02-13T19:40:08.040Z,"northern Qinghai, China",earthquake,8.88,1.821,0.051,124,reviewed,us,us
-2023-02-13T18:18:55.203Z,42.4347,145.1482,37.56,4.8,mb,59,134,1.537,1.02,us,us6000jnm3,2023-02-13T19:29:21.040Z,"Hokkaido, Japan region",earthquake,9,7.129,0.054,108,reviewed,us,us
-2023-02-13T15:15:05.789Z,37.9396,36.3113,10,4.1,mb,24,98,0.981,0.62,us,us6000jnlc,2023-02-13T18:04:26.040Z,"18 km WSW of Göksun, Turkey",earthquake,5.2,1.938,0.214,6,reviewed,us,us
-2023-02-13T14:58:05.854Z,45.1281,23.1746,10,5,mww,114,25,1.188,0.73,us,us6000jnl6,2023-02-17T08:57:08.791Z,"Romania",earthquake,4.97,1.802,0.057,30,reviewed,us,us
-2023-02-13T14:28:17.062Z,38.1252,38.5928,4.748,4.3,mb,51,108,0.987,0.75,us,us6000jnl4,2023-02-13T17:24:59.040Z,"eastern Turkey",earthquake,4.73,3.18,0.116,21,reviewed,us,us
-2023-02-13T11:59:17.228Z,36.8373,36.63,11.708,4.4,mwr,64,88,2.105,0.82,us,us6000jnks,2023-02-13T12:21:35.040Z,"9 km NE of A?a?? Karafak?l?, Turkey",earthquake,5.44,3.877,0.062,25,reviewed,us,us
-2023-02-13T05:57:02.239Z,46.611,151.5935,98.535,5.2,mww,119,26,6.077,0.56,us,us6000jnjc,2023-02-13T06:25:26.040Z,"",earthquake,8.58,4.176,0.08,15,reviewed,us,us
-2023-02-13T02:59:47.012Z,36.5078,70.3466,203.021,4,mb,17,85,2.232,0.73,us,us6000jniv,2023-02-13T03:48:32.040Z,"44 km E of Farkh?r, Afghanistan",earthquake,7.11,15.411,0.3,3,reviewed,us,us
-2023-02-13T01:02:42.568Z,37.7448,141.6829,56.649,4.6,mwr,103,121,3.026,0.81,us,us6000jnij,2023-02-13T10:01:22.634Z,"66 km ENE of Namie, Japan",earthquake,7.94,6.16,0.078,16,reviewed,us,us
-2023-02-12T22:52:59.864Z,38.0276,36.6322,10,4.5,mb,59,99,1.028,0.57,us,us6000jni7,2023-02-13T06:32:10.098Z,"Central Turkey",earthquake,4.53,1.855,0.08,46,reviewed,us,us
-2023-02-12T22:45:05.650Z,27.9619,87.9864,65.041,4,mb,34,66,2.402,0.89,us,us6000jni5,2023-02-13T22:13:10.040Z,"72 km NW of Mangan, India",earthquake,9.75,9.677,0.102,26,reviewed,us,us
-2023-02-12T21:26:18.592Z,20.4266,121.9572,120.976,4.4,mb,49,121,2.516,0.52,us,us6000jnhw,2023-02-12T22:54:35.040Z,"2 km SSW of Basco, Philippines",earthquake,11.01,8.422,0.095,32,reviewed,us,us
-2023-02-12T19:02:30.940Z,37.2414,37.0614,21.645,4.3,mb,51,132,1.872,0.77,us,us6000jnh5,2023-02-12T21:00:06.040Z,"29 km ENE of Nurda??, Turkey",earthquake,6.53,4.001,0.102,27,reviewed,us,us
-2023-02-12T18:44:31.816Z,40.4167,141.6773,105.85,4.3,mb,73,128,0.597,0.88,us,us6000jnh4,2023-02-12T19:31:00.040Z,"17 km ESE of Hachinohe, Japan",earthquake,5.17,4.964,0.073,54,reviewed,us,us
-2023-02-12T18:33:15.503Z,37.3899,37.048,15.731,4.7,mb,94,41,0.253,0.72,us,us6000jnh1,2023-02-12T20:12:18.292Z,"24 km SSE of Kahramanmara?, Turkey",earthquake,5.4,4.274,0.065,71,reviewed,us,us
-2023-02-12T18:21:46.328Z,27.901,53.8254,17.391,4.3,mb,34,67,3.635,0.67,us,us6000jngz,2023-02-13T11:03:09.478Z,"",earthquake,10.97,4.907,0.116,21,reviewed,us,us
-2023-02-12T17:28:17.880Z,38.0781,36.611,10,4.1,mb,18,79,0.978,0.8,us,us6000jngq,2023-02-12T18:16:40.040Z,"11 km ENE of Göksun, Turkey",earthquake,3.04,1.942,0.369,2,reviewed,us,us
-2023-02-12T16:29:49.720Z,38.8053,38.015,10,4.9,mb,41,65,0.381,1.02,us,us6000jngk,2023-02-14T14:49:30.040Z,"7 km E of Hekimhan, Turkey",earthquake,5.93,1.918,0.078,52,reviewed,us,us
-2023-02-12T15:19:36.199Z,32.7792,141.7648,24.929,4.5,mb,17,156,1.674,0.6,us,us6000jng8,2023-02-12T17:14:54.040Z,"294 km SSE of Katsuura, Japan",earthquake,11.02,7.318,0.191,8,reviewed,us,us
-2023-02-12T14:30:03.732Z,37.8673,36.6552,10,4.3,mb,21,76,0.822,1.04,us,us6000jng3,2023-02-12T16:46:41.045Z,"Central Turkey",earthquake,5.23,1.957,0.133,16,reviewed,us,us
-2023-02-12T13:29:14.930Z,38.0009,38.3289,10,4.6,mb,47,75,1.09,0.63,us,us6000jnfq,2023-02-12T16:06:52.560Z,"8 km ESE of Çelikhan, Turkey",earthquake,4.65,1.849,0.065,70,reviewed,us,us
-2023-02-12T12:25:23.077Z,36.774,36.7811,9.343,4.2,mb,43,71,0.525,0.45,us,us6000jnfg,2023-02-12T16:07:12.122Z,"17 km SW of Musabeyli, Turkey",earthquake,4.74,5.835,0.127,17,reviewed,us,us
-2023-02-12T10:48:14.834Z,26.3679,92.9309,10,4.3,mb,19,128,5.677,0.37,us,us6000jngh,2023-02-12T16:46:22.334Z,"32 km SSE of Tezpur, India",earthquake,11.56,1.957,0.188,8,reviewed,us,us
-2023-02-12T10:00:22.635Z,38.2548,38.5098,16.625,4.1,mb,22,75,0.848,0.42,us,us6000jnf7,2023-02-12T10:40:40.040Z,"19 km ESE of Malatya, Turkey",earthquake,2.71,4.975,0.214,6,reviewed,us,us
-2023-02-12T09:32:23.386Z,36.0908,36.3111,10,4.1,mb,24,74,1.299,0.46,us,us6000jnf4,2023-02-12T10:24:41.040Z,"5 km WNW of Hac?pa?a, Turkey",earthquake,4.42,1.927,0.184,8,reviewed,us,us
-2023-02-12T08:21:01.432Z,41.8789,42.251,10,4,mb,12,130,1.14,0.58,us,us6000jney,2023-02-12T08:52:56.371Z,"",earthquake,5.47,1.966,0.212,6,reviewed,us,us
-2023-02-12T08:07:01.419Z,41.8764,42.1314,10,4.2,mb,24,84,1.136,0.61,us,us6000jnex,2023-02-13T22:19:43.101Z,"11 km ESE of Ozurgeti, Georgia",earthquake,5.68,1.218,0.141,14,reviewed,us,us
-2023-02-12T04:52:59.662Z,37.9259,37.5096,10,4.2,mb,24,101,0.789,0.85,us,us6000jndz,2023-02-12T05:14:37.040Z,"7 km SE of Nurhak, Turkey",earthquake,4.27,1.947,0.176,9,reviewed,us,us
-2023-02-12T04:29:14.956Z,37.8213,38.2487,10,4.2,mb,23,122,1.05,0.87,us,us6000jndu,2023-02-12T04:44:09.040Z,"6 km NNW of Ad?yaman, Turkey",earthquake,3.04,1.95,0.236,5,reviewed,us,us
-2023-02-11T23:30:56.632Z,37.9909,36.4045,10,4.1,mb,43,47,0.965,0.69,us,us6000jncu,2023-02-12T00:04:53.040Z,"8 km WSW of Göksun, Turkey",earthquake,3.96,1.918,0.135,15,reviewed,us,us
-2023-02-11T22:29:16.392Z,36.6889,36.5403,10,4.2,mb,13,159,0.721,0.83,us,us6000jncp,2023-02-11T23:04:05.040Z,"10 km S of A?a?? Karafak?l?, Turkey",earthquake,4.09,2.003,0.121,19,reviewed,us,us
-2023-02-11T20:39:05.278Z,37.8159,37.9186,10,4.2,mb,33,83,0.855,0.92,us,us6000jnc0,2023-02-11T22:14:05.040Z,"2 km N of Tut, Turkey",earthquake,4.8,1.918,0.122,19,reviewed,us,us
-2023-02-11T17:50:17.060Z,38.1803,38.729,5.649,4.2,mb,49,104,0.962,0.64,us,us6000jnbi,2023-02-11T20:02:19.040Z,"18 km NNE of Sincik, Turkey",earthquake,3.41,5.021,0.104,28,reviewed,us,us
-2023-02-11T17:20:01.507Z,36.2131,36.1207,10,4.3,mb,76,73,1.297,0.8,us,us6000jnbd,2023-02-11T18:35:19.099Z,"2 km S of Günyaz?, Turkey",earthquake,6.28,1.866,0.073,61,reviewed,us,us
-2023-02-11T15:33:42.581Z,41.9458,42.2302,10,4.4,mb,33,55,1.072,0.73,us,us6000jnb2,2023-02-12T08:25:17.976Z,"18 km E of Ozurgeti, Georgia",earthquake,4.55,1.922,0.099,29,reviewed,us,us
-2023-02-11T14:38:04.145Z,37.9684,36.4994,10,4.4,mb,30,76,0.975,0.92,us,us6000jnay,2023-02-12T13:49:07.292Z,"5 km S of Göksun, Turkey",earthquake,4.95,1.915,0.105,26,reviewed,us,us
-2023-02-11T13:10:00.015Z,38.8618,38.0668,12.132,4.6,mb,68,46,0.312,0.79,us,us6000jnar,2023-02-15T01:53:07.040Z,"13 km ENE of Hekimhan, Turkey",earthquake,3.9,4.477,0.086,40,reviewed,us,us
-2023-02-11T12:54:58.737Z,38.0797,36.5974,5.699,4.1,mb,25,69,0.97,0.47,us,us6000jnaq,2023-02-11T13:07:45.040Z,"10 km NE of Göksun, Turkey",earthquake,3.58,7.741,0.233,5,reviewed,us,us
-2023-02-11T11:51:41.245Z,36.4205,36.3922,10,4.4,mb,40,166,0.997,0.5,us,us6000jnam,2023-02-11T20:21:09.849Z,"7 km NNW of Uzunkavak, Turkey",earthquake,6.12,1.93,0.144,14,reviewed,us,us
-2023-02-11T11:35:48.410Z,23.3995,121.5985,35.193,4.7,mb,73,83,0.277,0.61,us,us6000jnal,2023-02-11T12:08:39.040Z,"63 km S of Hualien City, Taiwan",earthquake,3.65,6.475,0.074,56,reviewed,us,us
-2023-02-11T11:05:16.816Z,38.0828,36.6437,10,4.4,mb,51,48,0.99,0.37,us,us6000jnai,2023-02-11T11:48:54.040Z,"14 km ENE of Göksun, Turkey",earthquake,4.6,1.891,0.11,24,reviewed,us,us
-2023-02-11T10:45:00.618Z,33.4861,137.3876,339.947,4.1,mb,61,72,1.36,0.45,us,us6000jnag,2023-02-11T11:26:23.040Z,"121 km SSE of Toba, Japan",earthquake,7.53,7.04,0.07,57,reviewed,us,us
-2023-02-11T09:03:36.029Z,37.9923,38.2507,6.127,4.4,mb,23,141,1.101,0.54,us,us6000jn9p,2023-02-11T09:33:31.040Z,"3 km SSE of Çelikhan, Turkey",earthquake,4.74,5.181,0.267,4,reviewed,us,us
-2023-02-11T07:55:42.595Z,37.0141,36.9831,7.232,4.5,mb,54,115,0.24,0.98,us,us6000jn9a,2023-02-15T01:57:04.040Z,"15 km NNE of Musabeyli, Turkey",earthquake,4.12,5.545,0.125,19,reviewed,us,us
-2023-02-11T06:28:13.065Z,37.9814,36.5916,10,4.6,mb,39,73,0.945,0.63,us,us6000jn97,2023-02-11T08:53:08.040Z,"9 km ESE of Göksun, Turkey",earthquake,5.72,1.908,0.173,10,reviewed,us,us
-2023-02-11T06:06:24.313Z,37.9638,38.207,10,4,mb,30,115,1.119,0.58,us,us6000jn8z,2023-02-11T12:20:09.765Z,"7 km SSW of Çelikhan, Turkey",earthquake,5.25,1.949,0.183,8,reviewed,us,us
-2023-02-11T05:09:32.729Z,51.4457,178.6224,60.919,4.4,mb,74,197,0.431,0.81,us,us6000jn8i,2023-02-11T16:54:50.049Z,"Rat Islands, Aleutian Islands, Alaska",earthquake,11.02,7.743,0.067,64,reviewed,us,us
-2023-02-11T04:47:04.443Z,37.7485,36.6102,10,4.2,mb,48,75,0.747,0.54,us,us6000jn8d,2023-02-11T05:16:15.040Z,"29 km NE of And?r?n, Turkey",earthquake,4.98,1.858,0.128,17,reviewed,us,us
-2023-02-11T03:38:25.495Z,37.983,38.49,15.886,4.2,mb,61,120,1.115,0.71,us,us6000jn88,2023-02-11T04:34:25.040Z,"12 km WSW of Sincik, Turkey",earthquake,4.22,4.397,0.11,23,reviewed,us,us
-2023-02-11T02:41:43.117Z,23.7701,114.5782,10,4.1,mb,19,59,1.539,0.47,us,us6000jn7u,2023-02-15T04:27:33.269Z,"11 km WNW of Heyuan, China",earthquake,8.08,1.925,0.262,4,reviewed,us,us
-2023-02-11T00:24:42.706Z,36.4575,36.6798,10,4.1,mb,35,168,0.83,0.72,us,us6000jn77,2023-02-11T00:55:07.040Z,"Turkey-Syria border region",earthquake,3.11,1.914,0.198,7,reviewed,us,us
-2023-02-10T20:12:46.943Z,38.0504,38.6025,10,4.2,mb,35,119,1.062,0.99,us,us6000jn5q,2023-02-10T23:05:51.040Z,"eastern Turkey",earthquake,2.21,1.912,0.146,14,reviewed,us,us
-2023-02-10T17:31:24.915Z,38.1657,38.5791,5.707,4.2,mb,43,100,0.945,0.52,us,us6000jn4x,2023-02-10T18:37:18.040Z,"14 km NNW of Sincik, Turkey",earthquake,3.49,4.305,0.113,22,reviewed,us,us
-2023-02-10T17:00:52.253Z,37.8433,36.3069,10,4.9,mww,141,36,0.982,0.88,us,us6000jn4r,2023-02-15T02:07:11.510Z,"24 km SE of Saimbeyli, Turkey",earthquake,4.8,1.832,0.075,17,reviewed,us,us
-2023-02-10T13:37:10.858Z,24.8687,143.464,11.936,4.7,mb,50,120,8.816,0.42,us,us6000jn3b,2023-02-11T06:40:19.040Z,"Volcano Islands, Japan region",earthquake,11.01,4.287,0.085,42,reviewed,us,us
-2023-02-10T10:01:23.319Z,38.1295,38.1979,10,4.1,mb,33,75,0.846,0.34,us,us6000jn2a,2023-02-17T09:11:55.040Z,"12 km NNW of Çelikhan, Turkey",earthquake,3.01,1.945,0.262,4,reviewed,us,us
-2023-02-10T09:02:51.105Z,37.9549,38.2183,10,4.2,mb,34,55,0.701,0.69,us,us6000jn1b,2023-02-17T09:01:51.040Z,"8 km SSW of Çelikhan, Turkey",earthquake,4.14,1.931,0.215,6,reviewed,us,us
-2023-02-10T08:17:28.501Z,34.995,35.2889,10,4.2,mb,28,206,1.608,0.74,us,us6000jn19,2023-02-10T14:17:06.732Z,"Lebanon - Syria region",earthquake,5.34,1.93,0.187,8,reviewed,us,us
-2023-02-10T04:50:24.897Z,38.175,38.1644,10,4.8,mb,55,79,1.255,0.76,us,us6000jn0h,2023-02-10T06:59:08.092Z,"15 km SSW of Ye?ilyurt, Turkey",earthquake,4.12,1.87,0.1,31,reviewed,us,us
-2023-02-10T04:44:11.405Z,48.8668,153.6963,105.885,4.4,mb,36,135,5.207,0.77,us,us6000jn0j,2023-02-10T05:32:54.040Z,"266 km SW of Severo-Kuril’sk, Russia",earthquake,6.98,8.232,0.112,23,reviewed,us,us
-2023-02-10T04:40:51.870Z,36.729,71.1203,209.786,4.2,mb,25,79,2.762,0.43,us,us6000jn0g,2023-02-10T13:10:08.662Z,"29 km ESE of Jurm, Afghanistan",earthquake,5.55,10.862,0.199,7,reviewed,us,us
-2023-02-10T02:03:42.936Z,38.0894,38.2087,10,4.4,mb,35,66,1.211,1.19,us,us6000jmzl,2023-02-10T02:23:12.040Z,"7 km NNW of Çelikhan, Turkey",earthquake,5.28,1.886,0.115,22,reviewed,us,us
-2023-02-10T01:51:00.509Z,37.8402,36.6189,10,4.9,mb,39,49,0.816,0.73,us,us6000jmzj,2023-02-15T02:13:02.040Z,"22 km SSE of Göksun, Turkey",earthquake,4.98,1.607,0.075,58,reviewed,us,us
-2023-02-10T01:29:25.282Z,19.1183,121.0681,36.727,4.9,mb,41,102,3.681,1.02,us,us6000jmzh,2023-02-10T01:47:38.040Z,"56 km N of Claveria, Philippines",earthquake,9.48,5.17,0.075,57,reviewed,us,us
-2023-02-09T22:06:39.722Z,36.9692,36.6923,10,4.2,mb,58,68,0.461,1.09,us,us6000jmvs,2023-02-09T22:31:50.040Z,"21 km SE of Hasanbeyli, Turkey",earthquake,4.63,1.68,0.101,27,reviewed,us,us
-2023-02-09T21:46:29.575Z,37.1667,36.8266,10,4.1,mb,39,84,0.306,0.52,us,us6000jmvn,2023-02-09T22:20:29.040Z,"Central Turkey",earthquake,4.34,1.718,0.151,12,reviewed,us,us
-2023-02-09T18:41:59.041Z,49.2798,155.9558,41.824,4.3,mb,30,170,4.114,0.71,us,us6000jmty,2023-02-10T17:00:59.040Z,"155 km S of Severo-Kuril’sk, Russia",earthquake,12.16,7.849,0.116,21,reviewed,us,us
-2023-02-09T16:06:33.828Z,31.9318,92.9334,15.14,4.1,mb,58,69,6.624,0.48,us,us6000jmrc,2023-02-09T18:28:46.040Z,"Eastern Xizang",earthquake,4.25,4.541,0.088,42,reviewed,us,us
-2023-02-09T09:46:56.179Z,38.0162,38.6105,15.872,4.3,mb,32,121,1.396,0.49,us,us6000jmpe,2023-02-09T20:34:21.991Z,"2 km S of Sincik, Turkey",earthquake,4.19,5.774,0.202,7,reviewed,us,us
-2023-02-09T07:42:09.215Z,38.0166,36.6317,10,4.3,mb,39,70,0.96,0.95,us,us6000jmnx,2023-02-09T08:01:19.040Z,"11 km E of Göksun, Turkey",earthquake,1.74,1.945,0.137,15,reviewed,us,us
-2023-02-09T07:18:16.806Z,36.924,36.6528,5.145,4.8,mb,71,39,0.51,0.58,us,us6000jmnp,2023-02-15T02:17:13.040Z,"Turkey-Syria border region",earthquake,4.91,4.653,0.074,56,reviewed,us,us
-2023-02-09T05:37:35.117Z,38.2127,38.1982,17.431,4.1,mb,27,104,1.302,0.61,us,us6000jmnc,2023-02-09T06:30:37.040Z,"10 km SSW of Ye?ilyurt, Turkey",earthquake,5.19,5.117,0.262,5,reviewed,us,us
-2023-02-09T04:34:45.360Z,38.0922,38.4552,15.995,4.3,mb,28,115,1.35,0.62,us,us6000jmn4,2023-02-10T03:15:15.040Z,"15 km WNW of Sincik, Turkey",earthquake,4.56,6.082,0.266,4,reviewed,us,us
-2023-02-09T03:52:19.732Z,38.0056,38.5425,14.891,4.5,mb,23,121,1.347,0.69,us,us6000jmmz,2023-02-10T02:57:19.040Z,"7 km WSW of Sincik, Turkey",earthquake,2.87,6.119,0.314,3,reviewed,us,us
-2023-02-09T03:24:55.884Z,36.8136,36.4252,10,4.3,mb,23,154,0.723,1.05,us,us6000jmmw,2023-02-10T02:37:05.040Z,"8 km W of Hassa, Turkey",earthquake,4.53,1.812,0.266,4,reviewed,us,us
-2023-02-09T01:44:20.184Z,37.8647,37.6676,13.664,4.4,mb,38,106,0.781,0.76,us,us6000jmma,2023-02-10T02:13:05.040Z,"9 km NNE of Gölba??, Turkey",earthquake,1.96,5.407,0.149,13,reviewed,us,us
-2023-02-09T01:38:13.965Z,38.4404,40.4232,7.791,4.4,mb,37,78,1.16,0.68,us,us6000jmm7,2023-02-10T02:08:02.040Z,"4 km NE of Hani, Turkey",earthquake,3.71,4.089,0.13,17,reviewed,us,us
-2023-02-09T00:32:17.238Z,38.4058,39.292,16.333,4.2,mb,20,101,1.604,0.92,us,us6000jmlx,2023-02-09T00:46:31.040Z,"eastern Turkey",earthquake,5.75,2.313,0.236,5,reviewed,us,us
-2023-02-08T22:36:50.425Z,38.2174,38.2049,16.084,4,mb,29,91,1.309,0.6,us,us6000jmll,2023-02-08T22:47:15.040Z,"9 km SSW of Ye?ilyurt, Turkey",earthquake,4.93,5.752,0.183,8,reviewed,us,us
-2023-02-08T20:12:06.247Z,38.2099,38.1438,10,4.5,mb,29,103,1.274,1.18,us,us6000jmkh,2023-02-09T06:18:17.917Z,"13 km SW of Ye?ilyurt, Turkey",earthquake,4.86,1.928,0.27,4,reviewed,us,us
-2023-02-08T18:58:53.997Z,34.1531,36.2324,10,4.2,mb,41,161,2.527,0.7,us,us6000jmjy,2023-02-09T15:16:20.598Z,"16 km N of Baalbek, Lebanon",earthquake,8.86,1.953,0.128,17,reviewed,us,us
-2023-02-08T17:57:23.222Z,39.7838,40.7847,10,4.5,mb,34,48,1.567,1.2,us,us6000jmjj,2023-02-11T11:13:10.882Z,"eastern Turkey",earthquake,3.41,1.911,0.135,16,reviewed,us,us
-2023-02-08T14:55:51.976Z,38.0117,38.5221,14.769,4.3,mb,59,67,1.338,0.45,us,us6000jmhi,2023-02-15T14:49:34.040Z,"8 km WSW of Sincik, Turkey",earthquake,5.52,4.669,0.114,22,reviewed,us,us
-2023-02-08T14:42:22.459Z,38.1117,36.6183,10,4.4,mb,58,67,0.955,0.81,us,us6000jmhg,2023-02-15T14:39:08.040Z,"14 km NE of Göksun, Turkey",earthquake,3.45,1.906,0.115,22,reviewed,us,us
+2023-02-13T14:58:05.854Z,45.1281,23.1746,10,5,mww,114,25,1.188,0.73,us,us6000jnl6,2023-02-17T08:57:08.791Z,Romania,earthquake,4.97,1.802,0.057,30,reviewed,us,us
 2023-02-08T14:20:25.727Z,37.9629,37.458,5.867,5.1,mww,143,55,0.814,0.88,us,us6000jmh3,2023-02-09T22:18:31.040Z,"1 km E of Nurhak, Turkey",earthquake,4.44,3.81,0.083,14,reviewed,us,us
-2023-02-08T11:24:01.531Z,37.9186,37.5934,8.695,4.6,mb,69,78,0.805,0.68,us,us6000jmgg,2023-02-09T22:29:05.040Z,"14 km ESE of Nurhak, Turkey",earthquake,4.59,4.336,0.084,42,reviewed,us,us
 2023-02-08T11:11:52.720Z,37.9467,37.6523,7.457,5.4,mww,112,44,0.849,0.8,us,us6000jmgf,2023-02-14T23:50:23.836Z,"18 km N of Gölba??, Turkey",earthquake,4.46,3.995,0.065,23,reviewed,us,us
-2023-02-08T11:00:20.006Z,38.0857,37.825,10,4.3,mb,28,98,1.035,0.5,us,us6000jmge,2023-02-09T22:42:35.040Z,"Central Turkey",earthquake,5.29,1.969,0.237,5,reviewed,us,us
-2023-02-08T10:49:59.354Z,23.3731,121.6213,31.168,4.8,mwr,97,40,0.298,0.76,us,us6000jmgd,2023-02-12T14:28:12.632Z,"66 km S of Hualien City, Taiwan",earthquake,3.66,4.366,0.06,27,reviewed,us,us
-2023-02-08T10:26:23.732Z,37.0457,37.0143,10,4.5,mb,68,115,0.201,0.89,us,us6000jmg9,2023-02-09T22:46:54.040Z,"19 km NNE of Musabeyli, Turkey",earthquake,4.59,1.867,0.09,36,reviewed,us,us
-2023-02-08T07:48:32.134Z,37.9993,36.4734,10,4.9,mb,70,24,0.983,0.96,us,us6000jmg1,2023-02-09T22:21:28.040Z,"3 km SW of Göksun, Turkey",earthquake,4.11,1.857,0.082,47,reviewed,us,us
-2023-02-08T06:39:01.947Z,42.9888,145.3592,53.335,4.4,mb,61,134,1.897,0.41,us,us6000jmfs,2023-02-08T08:02:42.040Z,"41 km SSW of Nemuro, Japan",earthquake,8.87,7.583,0.072,56,reviewed,us,us
-2023-02-08T06:09:01.827Z,36.3573,36.1303,10,4.4,mb,39,186,1.188,0.59,us,us6000jmfn,2023-02-08T07:09:30.941Z,"Turkey-Syria border region",earthquake,4.45,1.965,0.11,24,reviewed,us,us
-2023-02-08T05:52:37.740Z,38.0493,36.6816,10,4.6,mb,37,67,0.971,0.97,us,us6000jmfk,2023-02-09T22:37:19.040Z,"Central Turkey",earthquake,4.08,1.924,0.119,21,reviewed,us,us
-2023-02-08T04:52:02.006Z,46.4364,152.8927,35,4.6,mb,47,132,7.366,0.44,us,us6000jmff,2023-02-08T05:33:29.040Z,"Kuril Islands",earthquake,10.81,1.923,0.102,29,reviewed,us,us
-2023-02-08T04:01:16.829Z,32.265,49.7516,10,4.3,mb,21,86,4.92,0.47,us,us6000jmfb,2023-02-08T05:24:30.040Z,"western Iran",earthquake,7.44,1.826,0.153,12,reviewed,us,us
-2023-02-08T03:01:02.295Z,37.0315,36.7208,10,4.3,mb,24,113,0.415,0.49,us,us6000jmer,2023-02-08T04:58:49.040Z,"15 km S of Nurda??, Turkey",earthquake,4.59,1.96,0.177,9,reviewed,us,us
-2023-02-08T02:44:12.408Z,30.3499,138.3154,436.037,4,mb,47,108,3.038,0.38,us,us6000jmep,2023-02-08T04:49:59.040Z,"Izu Islands, Japan region",earthquake,10.77,7.318,0.098,28,reviewed,us,us
-2023-02-08T02:25:12.711Z,37.8719,38.1216,10,4.3,mb,44,101,1.007,0.62,us,us6000jmem,2023-02-08T04:36:20.040Z,"",earthquake,4.59,1.761,0.13,17,reviewed,us,us
-2023-02-08T00:11:56.157Z,38.1268,37.2542,17.189,4,mb,29,58,0.954,0.89,us,us6000jme5,2023-02-08T00:34:29.040Z,"9 km NE of Ekinözü, Turkey",earthquake,2.84,5.692,0.184,8,reviewed,us,us
-2023-02-07T23:13:01.426Z,35.9449,35.9074,10,4.5,mb,57,129,1.612,0.92,us,us6000jmdw,2023-02-07T23:53:51.950Z,"14 km WNW of Yaylada??, Turkey",earthquake,7.17,1.913,0.077,49,reviewed,us,us
-2023-02-07T22:45:27.921Z,38.0992,36.5507,6.069,4.2,mb,51,37,0.325,1.21,us,us6000jp4y,2023-02-16T04:17:23.040Z,"9 km NNE of Göksun, Turkey",earthquake,3.51,6.818,0.146,13,reviewed,us,us
-2023-02-07T22:07:54.879Z,38.0663,36.5541,12.635,4.2,mb,56,45,0.357,0.58,us,us6000jp4v,2023-02-16T05:07:17.040Z,"Central Turkey",earthquake,3.17,4.898,0.118,20,reviewed,us,us
-2023-02-07T21:58:54.224Z,37.4201,36.9564,12.635,4.1,mb,20,90,0.096,0.73,us,us6000jp4u,2023-02-16T05:14:51.040Z,"18 km S of Kahramanmara?, Turkey",earthquake,3.88,3.357,0.302,3,reviewed,us,us
-2023-02-07T21:21:26.864Z,37.8863,37.4652,10,4.9,mb,77,55,0.742,0.91,us,us6000jmc7,2023-02-08T00:54:33.549Z,"8 km SSE of Nurhak, Turkey",earthquake,4.25,1.847,0.06,89,reviewed,us,us
-2023-02-07T21:14:29.089Z,32.1292,35.283,10,4.1,mb,11,171,3.261,0.56,us,us6000jmcs,2023-02-14T16:57:31.007Z,"Dead Sea region",earthquake,9.11,1.984,0.301,4,reviewed,us,us
-2023-02-07T19:54:23.789Z,38.5952,39.9774,10,4.6,mwr,122,34,1.428,0.6,us,us6000jmbq,2023-02-07T22:56:20.040Z,"",earthquake,4.97,1.829,0.071,19,reviewed,us,us
-2023-02-07T19:13:48.746Z,38.1175,36.9616,5.404,4.4,mb,75,44,0.964,0.76,us,us6000jmbj,2023-02-07T22:39:10.040Z,"Central Turkey",earthquake,4.36,4.485,0.078,52,reviewed,us,us
 2023-02-07T18:10:00.474Z,37.9568,36.5992,21.625,5.3,mww,163,29,0.921,0.7,us,us6000jmat,2023-02-09T21:35:46.415Z,"11 km SE of Göksun, Turkey",earthquake,5.04,4.467,0.093,11,reviewed,us,us
-2023-02-07T17:38:00.954Z,37.8978,37.6231,20.542,4.2,mb,29,102,0.796,1.12,us,us6000jmar,2023-02-07T18:10:57.040Z,"12 km N of Gölba??, Turkey",earthquake,4.16,2.481,0.146,15,reviewed,us,us
-2023-02-07T15:48:53.715Z,38.0351,36.4807,8.309,5,mww,105,23,0.955,0.67,us,us6000jm96,2023-02-07T17:55:59.728Z,"Central Turkey",earthquake,3.77,3.613,0.062,25,reviewed,us,us
-2023-02-07T15:31:29.589Z,37.3122,37.1417,19.481,4.6,mb,89,75,0.15,0.7,us,us6000jm95,2023-02-07T16:05:48.995Z,"23 km SW of Pazarc?k, Turkey",earthquake,6.48,4.855,0.073,56,reviewed,us,us
-2023-02-07T13:36:41.580Z,36.0659,35.8787,10,4.4,mb,56,126,1.538,0.94,us,us6000jm84,2023-02-07T17:58:45.040Z,"16 km WSW of Uzunba?, Turkey",earthquake,5.87,1.892,0.094,33,reviewed,us,us
-2023-02-07T12:07:04.188Z,38.1924,38.2586,10,4.4,mb,42,39,1.315,0.67,us,us6000jm7q,2023-02-07T12:48:27.040Z,"11 km S of Ye?ilyurt, Turkey",earthquake,4.28,1.847,0.109,24,reviewed,us,us
-2023-02-07T10:56:30.804Z,37.8437,36.8362,10,4.4,mb,41,69,0.733,0.38,us,us6000jm7k,2023-02-07T14:12:07.040Z,"29 km NNW of Kahramanmara?, Turkey",earthquake,5.79,1.926,0.112,23,reviewed,us,us
-2023-02-07T10:53:22.293Z,40.1694,23.6373,10,4.9,mb,70,79,1.742,0.42,us,us6000jm7j,2023-02-07T18:39:27.336Z,"Greece",earthquake,2.62,1.874,0.069,66,reviewed,us,us
-2023-02-07T10:27:31.295Z,38.1343,38.1199,10,4.6,mb,63,67,1.202,0.51,us,us6000jm7h,2023-02-07T11:21:10.040Z,"",earthquake,2.54,1.883,0.08,46,reviewed,us,us
+2023-02-07T15:48:53.715Z,38.0351,36.4807,8.309,5,mww,105,23,0.955,0.67,us,us6000jm96,2023-02-07T17:55:59.728Z,Central Turkey,earthquake,3.77,3.613,0.062,25,reviewed,us,us
 2023-02-07T10:18:13.368Z,38.0026,38.5474,10,5.4,mww,94,29,1.348,0.56,us,us6000jm7f,2023-02-09T14:17:35.591Z,"6 km WSW of Sincik, Turkey",earthquake,5.35,1.838,0.073,18,reviewed,us,us
-2023-02-07T08:25:47.353Z,37.9445,37.4901,10,4.5,mb,31,72,0.803,0.71,us,us6000jm71,2023-02-07T08:48:18.040Z,"4 km ESE of Nurhak, Turkey",earthquake,4.14,1.949,0.127,18,reviewed,us,us
-2023-02-07T07:26:36.400Z,38.0354,37.6579,16.534,4.5,mb,35,113,0.932,0.62,us,us6000jm6v,2023-02-07T08:29:49.040Z,"19 km WSW of Do?an?ehir, Turkey",earthquake,3.66,5.223,0.171,10,reviewed,us,us
 2023-02-07T07:11:14.840Z,38.1162,38.6693,6.829,5.4,mww,119,29,1.494,0.59,us,us6000jm6p,2023-02-09T22:00:34.606Z,"10 km NNE of Sincik, Turkey",earthquake,5.51,3.665,0.052,36,reviewed,us,us
-2023-02-07T06:48:53.332Z,38.2378,37.5769,19.14,4.6,mb,58,67,1.103,0.69,us,us6000jm6b,2023-02-07T07:50:10.040Z,"30 km WNW of Do?an?ehir, Turkey",earthquake,4.83,5.244,0.093,35,reviewed,us,us
-2023-02-07T06:45:41.995Z,49.1754,155.8969,22.217,5.3,mww,91,74,4.098,0.51,us,us6000jm6a,2023-02-07T07:39:38.040Z,"167 km S of Severo-Kuril’sk, Russia",earthquake,7.92,4.94,0.086,13,reviewed,us,us
-2023-02-07T06:40:54.343Z,38.0531,36.4632,10,4.5,mb,37,74,0.933,0.45,us,us6000jm69,2023-02-07T07:13:13.040Z,"Central Turkey",earthquake,2.11,1.957,0.15,13,reviewed,us,us
-2023-02-07T05:26:31.390Z,36.1206,36.3448,18.551,4.4,mb,50,128,1.259,0.48,us,us6000jm63,2023-02-07T06:19:37.920Z,"5 km S of Boynuyo?un, Turkey",earthquake,5.64,4.995,0.124,19,reviewed,us,us
-2023-02-07T04:42:03.517Z,36.7885,36.6758,10,4.4,mb,40,117,0.574,0.69,us,us6000jm5v,2023-02-08T03:46:27.040Z,"10 km E of A?a?? Karafak?l?, Turkey",earthquake,4.11,1.939,0.13,17,reviewed,us,us
-2023-02-07T04:16:42.757Z,37.8735,37.3422,10,4.3,mb,20,87,0.708,0.37,us,us6000jm5s,2023-02-08T03:23:59.040Z,"13 km SW of Nurhak, Turkey",earthquake,2.84,1.965,0.532,1,reviewed,us,us
-2023-02-07T03:37:00.775Z,36.2739,36.2566,10,4.2,mb,27,194,1.179,0.73,us,us6000jm5j,2023-02-08T02:40:46.040Z,"3 km NNE of Kastal, Turkey",earthquake,7.29,1.972,0.176,9,reviewed,us,us
 2023-02-07T03:13:12.767Z,37.7582,37.7303,10,5.5,mww,131,45,0.717,0.6,us,us6000jm5e,2023-02-09T21:31:31.564Z,"8 km ESE of Gölba??, Turkey",earthquake,4.93,1.699,0.062,25,reviewed,us,us
-2023-02-07T03:08:57.191Z,37.9315,37.6463,10,4.6,mb,63,80,0.834,0.65,us,us6000jm5c,2023-02-08T01:41:31.908Z,"16 km N of Gölba??, Turkey",earthquake,4.11,1.913,0.093,35,reviewed,us,us
-2023-02-07T03:02:54.913Z,37.2628,37.2357,10,4.4,mb,28,71,0.093,0.62,us,us6000jm5a,2023-02-08T01:30:19.040Z,"25 km SSW of Pazarc?k, Turkey",earthquake,3.43,1.954,0.169,10,reviewed,us,us
-2023-02-07T02:53:27.542Z,37.9084,36.3859,10,4.3,mb,20,82,0.984,0.6,us,us6000jm57,2023-02-08T01:05:09.040Z,"15 km SW of Göksun, Turkey",earthquake,3.95,1.885,0.16,11,reviewed,us,us
-2023-02-07T02:47:37.006Z,35.9377,35.9777,10,4.8,mb,93,47,1.582,0.83,us,us6000jm55,2023-02-08T00:58:05.800Z,"8 km WNW of Yaylada??, Turkey",earthquake,5.91,1.838,0.063,78,reviewed,us,us
-2023-02-07T02:46:21.021Z,45.0164,80.9787,46.194,4,mb,20,65,1.923,0.74,us,us6000jm56,2023-02-08T00:23:22.040Z,"94 km ESE of Sarkand, Kazakhstan",earthquake,7.45,14.801,0.211,6,reviewed,us,us
-2023-02-07T02:43:28.064Z,38.116,36.9288,10,4.4,mb,24,57,0.968,0.59,us,us6000jm54,2023-02-08T00:10:06.040Z,"14 km S of Af?in, Turkey",earthquake,5.21,1.975,0.154,12,reviewed,us,us
-2023-02-07T02:39:03.922Z,38.6097,37.5098,15.771,4.2,mb,32,64,1.323,0.54,us,us6000jm53,2023-02-08T00:00:30.040Z,"7 km N of Darende, Turkey",earthquake,1.77,5.453,0.176,9,reviewed,us,us
-2023-02-07T02:30:56.818Z,26.8281,55.2072,10,4.5,mb,18,97,2.079,0.78,us,us6000jm52,2023-02-09T08:50:19.819Z,"44 km NE of Bandar-e Lengeh, Iran",earthquake,7.06,1.952,0.164,11,reviewed,us,us
-2023-02-07T01:34:30.485Z,37.4162,37.125,15.567,4.4,mb,30,73,0.253,0.95,us,us6000jm4x,2023-02-07T23:14:43.849Z,"17 km WSW of Pazarc?k, Turkey",earthquake,5.28,6.153,0.138,15,reviewed,us,us
-2023-02-07T01:29:19.249Z,38.0748,36.7378,10,4.1,mb,40,65,0.976,0.68,us,us6000jm4r,2023-02-07T22:28:16.040Z,"21 km ENE of Göksun, Turkey",earthquake,5.16,1.965,0.145,13,reviewed,us,us
-2023-02-06T23:29:15.039Z,35.6093,35.3527,10,4.5,mb,65,44,1.776,0.57,us,us6000jm3x,2023-02-07T01:26:45.238Z,"40 km WNW of Latakia, Syria",earthquake,5.13,1.851,0.097,31,reviewed,us,us
-2023-02-06T22:29:39.918Z,38.0525,36.4229,7.688,4.4,mb,45,75,0.917,0.77,us,us6000jm3n,2023-02-07T08:09:01.188Z,"7 km WNW of Göksun, Turkey",earthquake,3.95,4.274,0.095,33,reviewed,us,us
-2023-02-06T22:26:18.993Z,37.8818,37.4134,14.262,4.3,mb,46,68,0.727,1.38,us,us6000jm3l,2023-02-06T22:50:12.040Z,"9 km SSW of Nurhak, Turkey",earthquake,4.62,4.915,0.096,31,reviewed,us,us
-2023-02-06T22:11:37.240Z,38.152,38.2301,14.999,4.4,mb,51,94,1.27,0.65,us,us6000jm3f,2023-02-06T22:40:00.723Z,"14 km N of Çelikhan, Turkey",earthquake,4.9,3.044,0.093,33,reviewed,us,us
 2023-02-06T21:57:44.063Z,38.0372,36.6112,9.752,5.1,mb,93,28,0.986,0.9,us,us6000jm3c,2023-02-06T22:17:07.699Z,"10 km E of Göksun, Turkey",earthquake,5.9,2.145,0.045,163,reviewed,us,us
-2023-02-06T21:15:17.630Z,38.0646,37.0764,6.316,4.8,mb,94,49,0.897,0.76,us,us6000jm30,2023-02-06T21:29:41.040Z,"9 km W of Ekinözü, Turkey",earthquake,6.04,4.478,0.063,77,reviewed,us,us
-2023-02-06T21:02:03.594Z,36.54,36.4583,4.372,4.4,mb,54,132,0.872,0.97,us,us6000jm2x,2023-02-06T21:16:28.040Z,"10 km ENE of K?r?khan, Turkey",earthquake,5.17,3.4,0.088,37,reviewed,us,us
-2023-02-06T20:53:24.303Z,38.2085,38.2826,10,5,mb,100,55,1.34,0.83,us,us6000jm2v,2023-02-07T16:45:30.040Z,"eastern Turkey",earthquake,5.98,1.839,0.051,120,reviewed,us,us
-2023-02-06T20:44:00.097Z,37.9832,36.5543,10,4.9,mb,66,44,0.963,0.62,us,us6000jm2t,2023-02-07T16:41:35.040Z,"6 km SE of Göksun, Turkey",earthquake,3.26,1.849,0.059,91,reviewed,us,us
-2023-02-06T20:37:51.608Z,37.1953,37.0867,10,5.3,mww,125,28,0.101,0.74,us,us6000jm2r,2023-02-07T16:40:19.276Z,"Central Turkey",earthquake,5.69,1.801,0.071,19,reviewed,us,us
-2023-02-06T20:20:16.343Z,24.2731,121.8011,20.438,4.8,mb,68,85,0.213,1.08,us,us6000jm2l,2023-02-07T15:33:47.205Z,"Taiwan",earthquake,4.29,2.903,0.06,86,reviewed,us,us
-2023-02-06T20:14:11.915Z,37.995,36.5183,10,4.2,mb,37,75,0.988,0.71,us,us6000jm2k,2023-02-07T15:31:45.040Z,"3 km SSE of Göksun, Turkey",earthquake,4.67,1.354,0.118,20,reviewed,us,us
-2023-02-06T20:05:34.741Z,37.9925,36.3278,10,4.7,mb,73,38,0.938,0.72,us,us6000jm29,2023-02-07T15:24:44.040Z,"15 km WSW of Göksun, Turkey",earthquake,3.02,1.849,0.062,80,reviewed,us,us
-2023-02-06T19:49:40.124Z,38.1141,36.6304,10,4.3,mb,34,67,0.96,0.63,us,us6000jm28,2023-02-07T15:00:32.040Z,"15 km NE of Göksun, Turkey",earthquake,5.2,1.967,0.168,10,reviewed,us,us
-2023-02-06T19:40:16.073Z,38.027,38.1796,5.803,4.6,mb,89,54,1.15,0.7,us,us6000jm2a,2023-02-07T14:59:56.040Z,"5 km W of Çelikhan, Turkey",earthquake,5.11,4.895,0.065,71,reviewed,us,us
-2023-02-06T19:35:50.692Z,37.4716,37.1628,10,4.3,mb,43,59,0.301,0.69,us,us6000jm21,2023-02-06T22:39:01.069Z,"12 km W of Pazarc?k, Turkey",earthquake,3.19,1.912,0.111,23,reviewed,us,us
-2023-02-06T19:30:59.956Z,38.0636,37.334,10,4.4,mb,53,82,0.895,0.95,us,us6000jm1z,2023-02-06T22:35:20.040Z,"12 km E of Ekinözü, Turkey",earthquake,4.01,1.917,0.098,31,reviewed,us,us
-2023-02-06T19:15:47.703Z,37.9712,36.3823,10,4.4,mb,34,79,0.975,0.93,us,us6000jm1w,2023-02-06T22:33:15.040Z,"Central Turkey",earthquake,3.72,1.806,0.12,20,reviewed,us,us
+2023-02-06T20:53:24.303Z,38.2085,38.2826,10,5,mb,100,55,1.34,0.83,us,us6000jm2v,2023-02-07T16:45:30.040Z,eastern Turkey,earthquake,5.98,1.839,0.051,120,reviewed,us,us
+2023-02-06T20:37:51.608Z,37.1953,37.0867,10,5.3,mww,125,28,0.101,0.74,us,us6000jm2r,2023-02-07T16:40:19.276Z,Central Turkey,earthquake,5.69,1.801,0.071,19,reviewed,us,us
 2023-02-06T18:03:53.837Z,37.9815,36.4482,10,5.2,mww,112,20,0.989,0.77,us,us6000jm1p,2023-02-09T23:00:21.389Z,"6 km SW of Göksun, Turkey",earthquake,5,1.8,0.098,10,reviewed,us,us
-2023-02-06T18:02:44.519Z,38.1001,36.4785,10,4.4,mb,39,72,0.9,0.64,us,us6000jm1n,2023-02-06T22:17:58.040Z,"",earthquake,6.07,1.922,0.112,23,reviewed,us,us
-2023-02-06T17:46:49.973Z,38.0906,37.855,10,4.5,mb,51,83,1.05,1.09,us,us6000jm13,2023-02-06T22:15:27.040Z,"1 km WNW of Do?an?ehir, Turkey",earthquake,3.92,1.717,0.11,24,reviewed,us,us
-2023-02-06T17:31:33.226Z,36.967,36.7482,10,4.5,mb,56,86,0.422,1.24,us,us6000jly1,2023-02-06T22:01:25.040Z,"17 km WNW of Musabeyli, Turkey",earthquake,4.41,1.93,0.099,30,reviewed,us,us
-2023-02-06T17:26:24.437Z,38.0896,36.7014,10,4.7,mb,80,42,1.001,0.97,us,us6000jlwh,2023-02-06T21:59:00.040Z,"19 km ENE of Göksun, Turkey",earthquake,4.69,1.844,0.067,67,reviewed,us,us
-2023-02-06T17:22:01.451Z,38.0974,36.478,10,4.1,mb,24,77,0.902,1.1,us,us6000jlww,2023-02-06T21:54:09.040Z,"Central Turkey",earthquake,3.91,1.914,0.175,9,reviewed,us,us
-2023-02-06T17:11:47.700Z,37.9232,37.3396,10,4.3,mb,38,64,0.757,1.02,us,us6000jlu3,2023-02-06T21:59:24.040Z,"9 km WSW of Nurhak, Turkey",earthquake,5.49,1.955,0.133,16,reviewed,us,us
-2023-02-06T16:55:37.348Z,38.0975,37.4326,16.247,4.5,mb,82,67,1.455,0.51,us,us6000jlth,2023-02-06T20:45:06.040Z,"14 km N of Nurhak, Turkey",earthquake,6.06,4.438,0.077,49,reviewed,us,us
 2023-02-06T16:43:29.298Z,37.9616,36.4753,10,5,mb,126,34,0.981,0.77,us,us6000jlta,2023-02-09T22:55:21.040Z,"6 km SSW of Göksun, Turkey",earthquake,3.3,1.655,0.047,143,reviewed,us,us
-2023-02-06T16:32:11.313Z,36.6111,36.4444,10,4.9,mb,51,93,0.831,0.97,us,us6000jlt7,2023-02-06T18:40:09.801Z,"14 km NNE of K?r?khan, Turkey",earthquake,8.01,1.87,0.063,79,reviewed,us,us
-2023-02-06T16:26:39.603Z,38.0304,36.6206,10,4.8,mb,68,39,0.976,0.67,us,us6000jlt1,2023-02-06T16:45:58.040Z,"10 km E of Göksun, Turkey",earthquake,5.13,1.845,0.065,73,reviewed,us,us
-2023-02-06T16:26:15.509Z,37.9847,36.9072,10,4.6,mb,88,61,0.846,0.58,us,us6000jlt5,2023-02-06T17:02:26.040Z,"26 km WSW of Ekinözü, Turkey",earthquake,6.3,1.863,0.074,55,reviewed,us,us
-2023-02-06T16:06:43.568Z,38.0248,37.0728,10,4.3,mb,19,100,0.858,0.49,us,us6000jlsy,2023-02-06T17:43:52.040Z,"10 km WSW of Ekinözü, Turkey",earthquake,4.53,1.923,0.188,8,reviewed,us,us
-2023-02-06T15:33:32.803Z,38.161,38.1869,8.774,5.2,mb,94,66,1.255,0.94,us,us6000jlsu,2023-02-06T15:49:49.040Z,"eastern Turkey",earthquake,3.93,4.267,0.061,88,reviewed,us,us
+2023-02-06T15:33:32.803Z,38.161,38.1869,8.774,5.2,mb,94,66,1.255,0.94,us,us6000jlsu,2023-02-06T15:49:49.040Z,eastern Turkey,earthquake,3.93,4.267,0.061,88,reviewed,us,us
 2023-02-06T15:14:34.430Z,37.8679,37.7388,10,5.3,mb,108,55,0.812,0.73,us,us6000jlsq,2023-02-06T18:21:03.780Z,"12 km NE of Gölba??, Turkey",earthquake,4.92,1.838,0.046,156,reviewed,us,us
-2023-02-06T14:57:47.066Z,37.9248,37.9099,10,4.5,mb,25,108,1.867,0.59,us,us6000jlsn,2023-02-06T17:54:08.040Z,"14 km N of Tut, Turkey",earthquake,6.66,1.933,0.135,16,reviewed,us,us
-2023-02-06T14:51:16.243Z,38.0912,38.4342,10,4.4,mb,23,115,1.337,1.25,us,us6000jlsl,2023-02-06T17:37:32.040Z,"16 km WNW of Sincik, Turkey",earthquake,2.83,1.957,0.126,18,reviewed,us,us
-2023-02-06T14:41:57.408Z,38.1202,37.8325,10,4.4,mb,15,99,1.068,0.49,us,us6000jlsj,2023-02-06T18:03:15.040Z,"Central Turkey",earthquake,4.33,1.95,0.219,6,reviewed,us,us
-2023-02-06T14:29:58.740Z,37.9949,36.5123,10,4.7,mb,39,95,0.991,1.11,us,us6000jlsf,2023-02-06T17:49:03.040Z,"3 km SSE of Göksun, Turkey",earthquake,3.37,1.888,0.086,41,reviewed,us,us
-2023-02-06T14:27:43.378Z,36.7725,36.5341,10,4.5,mb,59,71,0.672,0.96,us,us6000jlse,2023-02-06T20:03:37.040Z,"2 km WSW of A?a?? Karafak?l?, Turkey",earthquake,5.05,1.893,0.083,42,reviewed,us,us
-2023-02-06T14:17:18.940Z,37.9517,37.3799,16.712,4.4,mb,44,88,0.783,0.7,us,us6000jlsd,2023-02-06T18:40:54.040Z,"5 km WSW of Nurhak, Turkey",earthquake,5.5,4.013,0.107,25,reviewed,us,us
-2023-02-06T14:10:11.931Z,37.8331,37.4605,16.453,4.5,mb,48,89,0.689,0.64,us,us6000jlsb,2023-02-06T18:26:20.040Z,"14 km S of Nurhak, Turkey",earthquake,5.63,5.044,0.086,40,reviewed,us,us
-2023-02-06T14:04:50.340Z,38.0339,36.5452,10,4.4,mb,46,72,0.984,0.74,us,us6000jls9,2023-02-06T17:26:32.040Z,"4 km ENE of Göksun, Turkey",earthquake,2.26,1.921,0.112,23,reviewed,us,us
-2023-02-06T13:44:51.613Z,37.9272,37.5076,17.336,5,mb,76,76,0.79,0.52,us,us6000jls6,2023-02-06T18:19:44.917Z,"Central Turkey",earthquake,4.95,1.715,0.061,84,reviewed,us,us
+2023-02-06T13:44:51.613Z,37.9272,37.5076,17.336,5,mb,76,76,0.79,0.52,us,us6000jls6,2023-02-06T18:19:44.917Z,Central Turkey,earthquake,4.95,1.715,0.061,84,reviewed,us,us
 2023-02-06T13:39:24.254Z,38.0166,37.7013,10,5.3,mb,221,33,0.929,1.23,us,us6000jls3,2023-02-16T21:46:47.405Z,"16 km WSW of Do?an?ehir, Turkey",earthquake,5.36,1.802,0.044,176,reviewed,us,us
-2023-02-06T13:36:08.640Z,36.3454,36.4775,10,4.2,mb,32,96,1.013,0.75,us,us6000jntr,2023-02-16T21:17:07.040Z,"5 km E of Uzunkavak, Turkey",earthquake,5.82,1.946,0.186,8,reviewed,us,us
-2023-02-06T13:33:15.653Z,37.9231,37.5399,15.685,4.2,mb,32,64,0.794,1.06,us,us6000jnu9,2023-02-16T21:05:19.040Z,"9 km ESE of Nurhak, Turkey",earthquake,5.73,3.69,0.235,5,reviewed,us,us
-2023-02-06T13:32:19.755Z,38.726,38.445,15.303,4.2,mb,30,69,1.317,0.54,us,us6000jnwm,2023-02-16T20:54:37.040Z,"16 km ESE of Arguvan, Turkey",earthquake,3.58,5.492,0.141,14,reviewed,us,us
-2023-02-06T13:31:39.632Z,36.3959,36.3691,10,4.5,mb,33,103,1.027,0.62,us,us6000jntn,2023-02-16T20:43:35.040Z,"6 km NW of Uzunkavak, Turkey",earthquake,5.39,1.915,0.135,16,reviewed,us,us
-2023-02-06T13:22:01.325Z,38.0367,37.3789,10.761,4.4,mb,40,71,0.874,0.49,us,us6000jntp,2023-02-15T22:48:17.040Z,"Central Turkey",earthquake,4.67,4.794,0.144,14,reviewed,us,us
-2023-02-06T13:17:42.209Z,37.9951,36.3843,10,4.9,mb,106,30,0.412,0.78,us,us6000jls0,2023-02-15T23:06:10.217Z,"",earthquake,5.62,1.798,0.057,98,reviewed,us,us
-2023-02-06T13:14:02.533Z,37.8769,37.8935,16.594,4.5,mb,28,154,1.88,1.01,us,us6000jntl,2023-02-15T15:38:40.040Z,"9 km NNW of Tut, Turkey",earthquake,6.91,5.047,0.131,17,reviewed,us,us
-2023-02-06T13:12:27.843Z,37.9077,36.5237,10,4.8,mb,50,81,1.082,0.61,us,us6000jnvk,2023-02-14T23:14:32.040Z,"",earthquake,5.57,1.857,0.118,22,reviewed,us,us
-2023-02-06T13:11:56.990Z,38.0104,36.6564,10,4.7,mb,61,42,0.945,0.74,us,us6000jlry,2023-02-14T22:54:42.040Z,"14 km E of Göksun, Turkey",earthquake,3.29,1.835,0.086,41,reviewed,us,us
-2023-02-06T13:09:21.082Z,36.2061,36.2521,10,4.6,mb,39,102,2.685,0.51,us,us6000jntm,2023-02-14T22:50:11.040Z,"1 km SSW of Aç?kdere, Turkey",earthquake,9.07,1.888,0.113,23,reviewed,us,us
 2023-02-06T13:07:45.530Z,38.0778,37.3746,18.767,5,mb,111,56,0.914,0.73,us,us6000jlrv,2023-02-14T21:45:43.508Z,"13 km NNW of Nurhak, Turkey",earthquake,6.01,4.064,0.052,115,reviewed,us,us
-2023-02-06T13:06:38.866Z,37.9553,37.261,17.86,4.5,mb,52,105,0.783,0.91,us,us6000jnu4,2023-02-14T21:38:44.040Z,"13 km SSE of Ekinözü, Turkey",earthquake,1.99,4.512,0.108,25,reviewed,us,us
-2023-02-06T13:03:18.930Z,38.0086,37.4892,16.477,4.6,mb,76,125,1.54,0.93,us,us6000jntk,2023-02-14T21:34:12.040Z,"Central Turkey",earthquake,5.69,4.021,0.085,41,reviewed,us,us
-2023-02-06T13:02:39.258Z,42.8104,69.1811,9.273,4.5,mb,45,93,1.02,0.77,us,us6000jlrs,2023-02-14T21:25:25.623Z,"24 km NNW of Temirlanovka, Kazakhstan",earthquake,5.57,4.882,0.151,13,reviewed,us,us
-2023-02-06T13:00:18.096Z,38.1094,36.691,10,4.5,mb,34,97,0.994,0.63,us,us6000jlrt,2023-02-14T21:19:59.040Z,"Central Turkey",earthquake,4.18,1.761,0.115,22,reviewed,us,us
-2023-02-06T12:54:40.287Z,37.7669,36.6981,10,4.6,mb,58,53,0.72,0.55,us,us6000jlrq,2023-02-07T09:54:04.040Z,"28 km NW of Kahramanmara?, Turkey",earthquake,5.54,1.886,0.094,34,reviewed,us,us
-2023-02-06T12:48:00.893Z,38.0257,36.884,10,4.3,mb,36,61,0.891,0.54,us,us6000jlrp,2023-02-07T09:38:53.040Z,"Central Turkey",earthquake,3,1.944,0.142,14,reviewed,us,us
-2023-02-06T12:36:36.913Z,38.101,38.2227,10,4.7,mb,39,110,1.227,0.39,us,us6000jlrk,2023-02-06T13:07:01.040Z,"8 km N of Çelikhan, Turkey",earthquake,5.81,1.922,0.095,34,reviewed,us,us
-2023-02-06T12:34:43.520Z,38.1116,38.244,13.017,4.9,mb,38,95,1.247,0.79,us,us6000jlrj,2023-02-06T18:18:34.081Z,"9 km N of Çelikhan, Turkey",earthquake,5.28,4.691,0.123,21,reviewed,us,us
-2023-02-06T12:21:18.935Z,38.0517,36.4276,10.588,4.4,mb,37,75,0.92,0.46,us,us6000jlrh,2023-02-07T09:25:15.590Z,"7 km WNW of Göksun, Turkey",earthquake,4.25,4.68,0.126,18,reviewed,us,us
-2023-02-06T12:13:47.350Z,37.9016,37.4176,10,4.8,mb,72,68,0.747,0.68,us,us6000jlrg,2023-02-06T12:52:12.040Z,"Central Turkey",earthquake,4.79,1.822,0.066,70,reviewed,us,us
 2023-02-06T12:02:11.825Z,38.0605,36.537,10,6,mb,116,29,0.958,1,us,us6000jlrc,2023-02-16T21:13:41.161Z,"5 km NE of Göksun, Turkey",earthquake,4.4,1.811,0.027,513,reviewed,us,us
-2023-02-06T11:58:36.837Z,38.0358,37.5511,10,4.8,mb,58,73,0.904,0.61,us,us6000jlrb,2023-02-06T13:22:26.040Z,"12 km NE of Nurhak, Turkey",earthquake,3.42,1.866,0.073,58,reviewed,us,us
-2023-02-06T11:51:21.916Z,38.0348,37.6784,15.908,4.5,mb,52,98,0.938,0.54,us,us6000jm76,2023-02-07T09:11:13.040Z,"17 km WSW of Do?an?ehir, Turkey",earthquake,5.11,4.392,0.096,32,reviewed,us,us
-2023-02-06T11:50:05.703Z,37.9577,36.3019,10,4.5,mb,47,82,0.962,0.66,us,us6000jlra,2023-02-07T09:01:52.040Z,"Central Turkey",earthquake,4.38,1.512,0.106,26,reviewed,us,us
-2023-02-06T11:39:41.423Z,38.0562,36.5829,10,4.8,mb,54,48,0.982,0.6,us,us6000jlr7,2023-02-06T14:14:34.040Z,"8 km ENE of Göksun, Turkey",earthquake,4.99,1.868,0.08,48,reviewed,us,us
-2023-02-06T11:35:29.956Z,37.9614,37.3495,16.888,4.5,mb,78,64,0.796,0.48,us,us6000jlr9,2023-02-07T08:46:04.397Z,"7 km W of Nurhak, Turkey",earthquake,4.43,4.422,0.079,47,reviewed,us,us
-2023-02-06T11:28:01.748Z,37.9576,38.2435,15.558,4.3,mb,41,119,1.136,0.47,us,us6000jlr0,2023-02-07T06:10:59.040Z,"7 km S of Çelikhan, Turkey",earthquake,2.89,4.891,0.123,19,reviewed,us,us
-2023-02-06T11:11:41.258Z,37.82,37.2952,17.971,4.9,mb,65,74,0.65,0.83,us,us6000jlqx,2023-02-06T18:17:14.832Z,"8 km N of Ça?layancerit, Turkey",earthquake,5.77,4.455,0.082,47,reviewed,us,us
-2023-02-06T11:05:35.742Z,37.9231,36.6909,10,5.2,mb,55,134,1.14,0.89,us,us6000jlqr,2023-02-06T18:18:05.114Z,"Central Turkey",earthquake,6.76,1.706,0.087,43,reviewed,us,us
+2023-02-06T11:05:35.742Z,37.9231,36.6909,10,5.2,mb,55,134,1.14,0.89,us,us6000jlqr,2023-02-06T18:18:05.114Z,Central Turkey,earthquake,6.76,1.706,0.087,43,reviewed,us,us
 2023-02-06T11:01:34.428Z,37.4806,37.2218,10,5,mb,27,239,1.746,0.78,us,us6000jlqy,2023-02-06T18:10:00.466Z,"6 km W of Pazarc?k, Turkey",earthquake,14.65,1.982,0.15,14,reviewed,us,us
 2023-02-06T10:51:30.942Z,38.1236,38.0529,12.336,5.7,mb,88,69,1.162,0.97,us,us6000jlql,2023-02-08T06:06:26.219Z,"16 km ENE of Do?an?ehir, Turkey",earthquake,5.65,4.266,0.051,139,reviewed,us,us
 2023-02-06T10:35:58.653Z,38.0084,37.7505,10,5.8,mb,67,67,0.939,0.88,us,us6000jlqe,2023-02-07T10:41:46.479Z,"13 km SW of Do?an?ehir, Turkey",earthquake,4.9,1.844,0.057,112,reviewed,us,us
-2023-02-06T10:26:48.486Z,38.0302,37.9636,20.094,6,mb,59,63,1.045,0.62,us,us6000jm1y,2023-02-11T19:40:16.234Z,"Central Turkey",earthquake,2.91,4.649,0.084,53,reviewed,us,us
-2023-02-06T10:24:49.258Z,38.0235,37.203,10,7.5,mww,135,17,0.85,0.93,us,us6000jlqa,2023-02-16T22:01:55.501Z,"4 km SSE of Ekinözü, Turkey",earthquake,4.94,1.824,0.041,58,reviewed,us,us
-2023-02-06T09:36:16.401Z,37.1957,36.8183,10,4.3,mb,28,143,0.313,0.97,us,us6000jlq5,2023-02-06T10:41:01.284Z,"Central Turkey",earthquake,6.32,1.948,0.147,13,reviewed,us,us
-2023-02-06T09:23:45.706Z,36.9839,36.4927,10,4.6,mb,54,78,0.603,0.84,us,us6000jlq1,2023-02-06T09:49:42.040Z,"Turkey-Syria border region",earthquake,5.61,1.882,0.086,40,reviewed,us,us
-2023-02-06T09:21:02.855Z,37.9691,38.099,14.828,4.4,mb,34,144,1.976,0.78,us,us6000jlq2,2023-02-13T10:31:33.040Z,"eastern Turkey",earthquake,6.52,4.729,0.131,17,reviewed,us,us
-2023-02-06T08:58:35.484Z,38.054,38.2569,15.265,4.5,mb,62,98,1.211,0.57,us,us6000jlpx,2023-02-06T14:34:04.040Z,"3 km NNE of Çelikhan, Turkey",earthquake,5.46,4.57,0.084,42,reviewed,us,us
-2023-02-06T08:52:37.335Z,37.449,37.2334,10,4.8,mb,58,61,0.277,0.78,us,us6000jlpv,2023-02-06T09:31:48.040Z,"7 km SW of Pazarc?k, Turkey",earthquake,7.54,1.884,0.072,60,reviewed,us,us
-2023-02-06T08:01:46.065Z,36.6629,36.477,10,4.5,mb,54,81,0.777,0.71,us,us6000jlpp,2023-02-06T10:38:08.040Z,"14 km SSW of A?a?? Karafak?l?, Turkey",earthquake,3.28,1.904,0.093,34,reviewed,us,us
-2023-02-06T07:41:14.045Z,37.8608,38.086,10,4.6,mb,38,100,0.979,0.44,us,us6000jlpi,2023-02-09T08:19:35.040Z,"16 km ENE of Tut, Turkey",earthquake,4.25,1.695,0.114,23,reviewed,us,us
-2023-02-06T07:08:31.825Z,36.7072,36.6722,13.429,4.6,mb,61,157,0.633,0.5,us,us6000jlpb,2023-02-06T22:24:05.795Z,"12 km SE of A?a?? Karafak?l?, Turkey",earthquake,3.82,5.269,0.105,27,reviewed,us,us
-2023-02-06T06:54:57.488Z,37.6414,37.3835,10,4.8,mb,85,69,0.489,0.55,us,us6000jlp9,2023-02-06T07:16:55.040Z,"",earthquake,8.95,1.871,0.065,74,reviewed,us,us
-2023-02-06T06:26:29.533Z,37.483,37.1811,10,4.6,mb,50,99,0.311,0.64,us,us6000jlsg,2023-02-06T15:34:10.040Z,"10 km W of Pazarc?k, Turkey",earthquake,5.34,1.915,0.095,33,reviewed,us,us
-2023-02-06T06:26:10.752Z,36.5684,36.0133,10,4.6,mb,32,97,1.133,0.55,us,us6000jlp5,2023-02-06T10:49:17.040Z,"14 km W of ?skenderun, Turkey",earthquake,10.03,1.921,0.107,26,reviewed,us,us
-2023-02-06T05:55:51.598Z,37.9912,38.4376,16.542,4.5,mb,51,104,1.273,0.58,us,us6000jlp1,2023-02-06T06:13:26.040Z,"16 km WSW of Sincik, Turkey",earthquake,4.74,4.727,0.093,34,reviewed,us,us
-2023-02-06T05:36:33.996Z,36.3185,36.2325,10.617,4.6,mb,57,133,1.158,0.53,us,us6000jlp0,2023-02-06T05:56:51.040Z,"3 km E of Anayaz?, Turkey",earthquake,7.53,5.353,0.081,45,reviewed,us,us
-2023-02-06T05:31:23.531Z,38.1466,37.9304,10,4.4,mb,37,85,1.129,0.92,us,us6000jlnz,2023-02-06T16:08:17.040Z,"8 km NE of Do?an?ehir, Turkey",earthquake,3.07,1.91,0.118,21,reviewed,us,us
-2023-02-06T05:22:50.001Z,37.7548,37.9481,10,4.4,mb,35,101,0.827,0.65,us,us6000jlnx,2023-02-06T15:52:05.040Z,"5 km SSE of Tut, Turkey",earthquake,3.34,1.912,0.11,24,reviewed,us,us
-2023-02-06T05:01:51.307Z,37.7637,37.9099,20.234,4.6,mb,52,99,0.812,0.63,us,us6000jlnv,2023-02-06T05:49:30.040Z,"Central Turkey",earthquake,5.84,5.119,0.073,56,reviewed,us,us
-2023-02-06T04:56:05.209Z,37.4399,37.1504,15.136,4.6,mb,58,71,0.271,0.88,us,us6000jlnu,2023-02-07T00:26:00.040Z,"14 km WSW of Pazarc?k, Turkey",earthquake,6.65,5.128,0.083,43,reviewed,us,us
-2023-02-06T04:47:57.486Z,36.7445,36.4537,10,4.4,mb,48,148,0.741,1.13,us,us6000jlns,2023-02-06T05:09:29.040Z,"8 km SW of Hassa, Turkey",earthquake,3.53,1.92,0.106,26,reviewed,us,us
-2023-02-06T04:39:47.705Z,37.8053,37.4694,14.865,4.3,mb,42,97,0.665,0.76,us,us6000jlnq,2023-02-06T06:34:43.040Z,"14 km W of Gölba??, Turkey",earthquake,2.98,5.708,0.105,26,reviewed,us,us
-2023-02-06T04:18:46.788Z,38.2034,38.5363,14.464,5,mb,95,44,1.472,0.86,us,us6000jlnf,2023-02-06T19:50:36.936Z,"eastern Turkey",earthquake,6.57,4.287,0.057,99,reviewed,us,us
-2023-02-06T04:16:49.487Z,37.5032,37.3323,13.215,4.5,mb,57,74,0.345,0.76,us,us6000jlnd,2023-02-06T04:39:00.585Z,"3 km ENE of Pazarc?k, Turkey",earthquake,5.37,5.371,0.093,34,reviewed,us,us
-2023-02-06T04:14:19.101Z,38.2387,38.581,16.715,4.4,mb,42,183,2.319,0.99,us,us6000jlne,2023-02-06T06:16:55.040Z,"22 km N of Sincik, Turkey",earthquake,8.94,6.142,0.101,28,reviewed,us,us
-2023-02-06T04:07:23.021Z,51.0729,179.413,3.5,2.9,ml,,,,0.4,ak,ak0231p9b4n8,2023-02-15T21:55:31.076Z,"288 km WSW of Adak, Alaska",earthquake,,0.3,,,reviewed,ak,ak
-2023-02-06T04:04:23.657Z,37.7879,37.4088,14.137,4.3,mb,39,106,0.635,0.58,us,us6000jlnc,2023-02-06T04:20:28.040Z,"11 km ENE of Ça?layancerit, Turkey",earthquake,6.11,5.858,0.109,24,reviewed,us,us
-2023-02-06T03:45:48.563Z,38.1983,38.5977,15.415,4.8,mb,97,66,1.504,0.75,us,us6000jln9,2023-02-06T04:33:27.159Z,"18 km N of Sincik, Turkey",earthquake,5.44,4.074,0.07,63,reviewed,us,us
-2023-02-06T03:32:15.796Z,26.4267,125.9658,126.894,4.2,mb,23,84,2.105,0.6,us,us6000jln4,2023-02-06T03:54:08.040Z,"173 km W of Naha, Japan",earthquake,3.73,10.47,0.215,6,reviewed,us,us
-2023-02-06T03:28:46.802Z,38.0757,38.5607,15.951,4.4,mb,26,145,1.402,0.58,us,us6000jln5,2023-02-06T04:23:56.040Z,"6 km NW of Sincik, Turkey",earthquake,5.98,5.029,0.149,13,reviewed,us,us
-2023-02-06T03:12:12.595Z,37.4711,37.3091,12.567,4.5,mb,52,79,3.561,0.99,us,us6000jln3,2023-02-06T06:07:10.575Z,"1 km SSE of Pazarc?k, Turkey",earthquake,9.53,4.642,0.083,42,reviewed,us,us
-2023-02-06T03:10:21.025Z,37.7473,37.8035,21.433,4.4,mb,61,95,0.744,0.77,us,us6000jln6,2023-02-07T00:52:12.040Z,"7 km NW of Besni, Turkey",earthquake,5.14,4.493,0.08,45,reviewed,us,us
-2023-02-06T03:04:45.466Z,38.1844,38.4761,17.922,4.7,mb,91,66,1.425,0.86,us,us6000jln0,2023-02-06T03:36:13.040Z,"20 km NW of Sincik, Turkey",earthquake,6.21,4.213,0.067,67,reviewed,us,us
-2023-02-06T02:54:00.615Z,36.6379,36.3874,10,4.6,mb,87,72,0.848,1,us,us6000jlmv,2023-02-06T04:57:12.221Z,"15 km E of Denizciler, Turkey",earthquake,6.37,1.884,0.064,74,reviewed,us,us
+2023-02-06T10:26:48.486Z,38.0302,37.9636,20.094,6,mb,59,63,1.045,0.62,us,us6000jm1y,2023-02-11T19:40:16.234Z,Central Turkey,earthquake,2.91,4.649,0.084,53,reviewed,us,us
+2023-02-06T10:24:49.258Z,38.0235,37.203,10,7.5,mww,135,17,0.85,0.93,us,us6000jlqa,2023-02-17T20:24:03.165Z,"4 km SSE of Ekinözü, Turkey",earthquake,4.94,1.824,0.041,58,reviewed,us,us
+2023-02-06T04:18:46.788Z,38.2034,38.5363,14.464,5,mb,95,44,1.472,0.86,us,us6000jlnf,2023-02-06T19:50:36.936Z,eastern Turkey,earthquake,6.57,4.287,0.057,99,reviewed,us,us
 2023-02-06T02:23:14.645Z,37.2035,36.9702,11.411,5.2,mb,107,36,0.194,0.81,us,us6000jlmn,2023-02-06T03:22:25.602Z,"21 km E of Nurda??, Turkey",earthquake,5.15,4.282,0.061,88,reviewed,us,us
-2023-02-06T02:21:17.499Z,37.0893,36.6997,10,4.2,mb,27,102,0.416,0.89,us,us6000jmn5,2023-02-09T04:58:45.040Z,"Central Turkey",earthquake,5.1,1.917,0.118,20,reviewed,us,us
-2023-02-06T02:17:40.302Z,37.0791,36.6898,10,4.8,mb,39,191,0.426,0.69,us,us6000jlmm,2023-02-06T02:51:13.040Z,"10 km SSW of Nurda??, Turkey",earthquake,3.45,1.957,0.1,31,reviewed,us,us
-2023-02-06T02:16:04.118Z,36.876,36.6494,10,4.1,mb,14,210,0.537,0.63,us,us6000jmn3,2023-02-09T04:44:32.040Z,"13 km NE of A?a?? Karafak?l?, Turkey",earthquake,5.85,2,0.234,5,reviewed,us,us
-2023-02-06T02:06:24.022Z,37.8592,38.1822,15.108,4.9,mb,85,67,1.034,0.9,us,us6000jmn0,2023-02-09T04:30:51.040Z,"13 km NW of Ad?yaman, Turkey",earthquake,4.63,4.395,0.069,67,reviewed,us,us
 2023-02-06T02:03:36.258Z,37.7769,37.9199,10,5.5,mb,64,45,0.827,0.8,us,us6000jlmh,2023-02-07T02:09:13.772Z,"2 km S of Tut, Turkey",earthquake,5.18,1.806,0.055,114,reviewed,us,us
-2023-02-06T02:01:45.663Z,37.3549,37.0939,10.358,4.8,mb,53,81,0.204,0.9,us,us6000jlmy,2023-02-06T03:14:00.040Z,"23 km SW of Pazarc?k, Turkey",earthquake,4.9,4.435,0.089,39,reviewed,us,us
 2023-02-06T01:58:23.594Z,37.1023,36.6056,10,5.1,mb,65,121,0.488,0.72,us,us6000jlmf,2023-02-06T02:48:59.040Z,"6 km ESE of Hasanbeyli, Turkey",earthquake,6.15,1.867,0.072,62,reviewed,us,us
-2023-02-06T01:51:43.437Z,37.4754,37.1529,7.008,4.7,mb,73,95,0.306,0.69,us,us6000jm4n,2023-02-15T06:08:55.040Z,"13 km W of Pazarc?k, Turkey",earthquake,5.38,4.384,0.08,47,reviewed,us,us
-2023-02-06T01:50:10.120Z,38.2291,38.7493,14.835,4.8,mb,76,112,2.359,0.66,us,us6000jns9,2023-02-15T06:02:49.040Z,"24 km NNE of Sincik, Turkey",earthquake,6.99,4.674,0.094,35,reviewed,us,us
-2023-02-06T01:48:12.420Z,37.9874,38.1051,10,4.9,mb,56,96,1.081,1.03,us,us6000jlmd,2023-02-07T01:51:45.040Z,"12 km WSW of Çelikhan, Turkey",earthquake,6.23,1.9,0.09,39,reviewed,us,us
-2023-02-06T01:41:15.229Z,37.9786,38.5121,14.415,4.6,mb,49,112,2.268,0.66,us,us6000jnvq,2023-02-15T05:46:57.040Z,"10 km SW of Sincik, Turkey",earthquake,5.02,5.113,0.119,21,reviewed,us,us
-2023-02-06T01:36:27.357Z,36.9921,36.6832,10,5.6,mb,167,47,0.458,0.59,us,us6000jlm9,2023-02-15T04:12:06.711Z,"Turkey-Syria border region",earthquake,6.2,1.76,0.052,128,reviewed,us,us
-2023-02-06T01:28:15.984Z,37.1784,36.9468,10.708,6.7,mww,192,19,0.21,0.57,us,us6000jlm1,2023-02-15T04:03:35.353Z,"Central Turkey",earthquake,8.97,3.408,0.098,10,reviewed,us,us
-2023-02-06T01:26:50.760Z,37.2241,36.9749,10,5.7,mb,97,75,0.194,1.33,us,us6000jlnn,2023-02-15T03:13:13.851Z,"",earthquake,5.4,1.828,0.072,69,reviewed,us,us
-2023-02-06T01:17:35.525Z,37.1662,37.0421,17.943,7.8,mww,216,17,0.134,0.67,us,us6000jllz,2023-02-16T22:06:20.211Z,"27 km E of Nurda??, Turkey",earthquake,6.27,3.278,0.05,38,reviewed,us,us
-2023-02-05T21:58:49.467Z,27.208,143.4892,10,4.7,mb,41,137,10.329,0.77,us,us6000jllc,2023-02-05T22:56:47.040Z,"",earthquake,12.32,1.901,0.078,50,reviewed,us,us
-2023-02-05T21:40:40.408Z,18.3847,145.3101,538.6,4.3,mb,57,75,4.787,0.36,us,us6000jll6,2023-02-05T22:17:07.040Z,"Pagan region, Northern Mariana Islands",earthquake,12.48,8.017,0.048,122,reviewed,us,us
-2023-02-05T12:58:22.835Z,48.9436,157.3246,48.287,4.5,mb,45,136,4.17,0.33,us,us6000jljv,2023-02-05T13:17:08.040Z,"211 km SSE of Severo-Kuril’sk, Russia",earthquake,9.95,7.22,0.091,36,reviewed,us,us
-2023-02-05T02:09:43.699Z,32.7725,141.7512,10,4.4,mb,22,140,1.665,0.88,us,us6000jn3j,2023-02-11T00:55:13.040Z,"294 km SSE of Katsuura, Japan",earthquake,8.43,1.928,0.202,7,reviewed,us,us
-2023-02-05T01:14:22.508Z,55.8678,162.6442,54.278,4.8,mb,61,112,3.682,0.92,us,us6000jlhk,2023-02-05T01:33:29.040Z,"41 km SSE of Ust’-Kamchatsk Staryy, Russia",earthquake,9.33,7.129,0.048,136,reviewed,us,us
-2023-02-05T00:03:19.589Z,32.6723,141.7624,10,5.8,mww,176,72,1.698,0.85,us,us6000jlh9,2023-02-06T00:10:18.635Z,"Izu Islands, Japan region",earthquake,6.05,1.813,0.058,29,reviewed,us,us
-2023-02-04T21:24:55.530Z,37.2442,71.4366,151.861,4.3,mb,29,75,2.248,0.66,us,us6000jlgk,2023-02-05T21:46:55.988Z,"29 km SSW of Khorugh, Tajikistan",earthquake,5.85,14.572,0.216,6,reviewed,us,us
-2023-02-04T16:40:40.024Z,22.8501,144.0089,40.137,4.5,mb,33,122,9.247,0.78,us,us6000jlf8,2023-02-04T18:33:01.040Z,"Volcano Islands, Japan region",earthquake,13.41,8.136,0.076,51,reviewed,us,us
-2023-02-04T12:23:26.144Z,37.4308,72.719,57.398,4.7,mb,52,65,2.167,0.51,us,us6000jldt,2023-02-04T12:48:59.040Z,"64 km NE of Khand?d, Afghanistan",earthquake,6.35,7.817,0.071,61,reviewed,us,us
-2023-02-04T10:47:31.230Z,36.3676,71.0578,159.642,4.1,mb,21,86,2.455,0.37,us,us6000jldc,2023-02-04T11:17:14.040Z,"55 km SW of Ashk?sham, Afghanistan",earthquake,7.19,15.039,0.261,4,reviewed,us,us
-2023-02-04T07:34:41.429Z,22.7357,95.9238,10,4.2,mb,25,127,2.213,0.61,us,us6000jlcr,2023-02-15T13:07:31.040Z,"29 km NE of Shwebo, Myanmar",earthquake,5.42,1.92,0.153,12,reviewed,us,us
-2023-02-04T06:04:14.851Z,34.9107,14.2405,10,4.7,mb,55,101,4.085,0.51,us,us6000jlch,2023-02-15T12:58:43.824Z,"central Mediterranean Sea",earthquake,4.72,1.802,0.092,36,reviewed,us,us
-2023-02-04T03:37:21.492Z,36.664,71.2662,219.586,4.2,mb,27,136,2.84,0.52,us,us6000jlbv,2023-02-04T03:52:13.040Z,"23 km W of Ashk?sham, Afghanistan",earthquake,7.01,10.243,0.176,9,reviewed,us,us
-2023-02-04T02:45:46.062Z,34.3437,45.7045,10,4.7,mb,50,67,3.414,0.69,us,us6000jlbp,2023-02-04T10:42:19.958Z,"Iran-Iraq border region",earthquake,8.61,1.777,0.06,83,reviewed,us,us
-2023-02-04T01:51:22.697Z,21.4639,144.0206,133.188,4.4,mb,27,122,5.851,0.93,us,us6000jn1l,2023-02-10T22:55:39.040Z,"Mariana Islands region",earthquake,13.18,7.949,0.138,15,reviewed,us,us
-2023-02-04T00:55:00.595Z,51.2966,178.9579,36.4,2.5,ml,,,,0.31,ak,ak0231lw4tkc,2023-02-14T23:18:44.728Z,"",earthquake,,0.9,,,reviewed,ak,ak
-2023-02-03T21:22:52.552Z,36.4123,70.7751,199.36,4.3,mb,56,82,3.166,0.64,us,us6000jl9j,2023-02-03T22:01:46.040Z,"50 km S of Jurm, Afghanistan",earthquake,7.2,7.682,0.08,44,reviewed,us,us
-2023-02-03T12:44:14.853Z,36.7689,21.6393,29.528,4.2,mb,43,185,0.469,0.58,us,us6000jl5y,2023-02-13T06:02:38.040Z,"8 km SW of Methóni, Greece",earthquake,8.15,4.144,0.137,15,reviewed,us,us
-2023-02-03T12:14:40.692Z,37.0695,96.9059,10,5,mb,78,43,12.445,0.49,us,us6000jl5u,2023-02-13T05:55:05.040Z,"northern Qinghai, China",earthquake,8.47,1.847,0.048,139,reviewed,us,us
-2023-02-03T12:04:19.597Z,37.0312,96.9146,10,5,mww,110,32,12.424,0.43,us,us6000jl5t,2023-02-13T05:51:46.795Z,"northern Qinghai, China",earthquake,8.14,1.84,0.08,15,reviewed,us,us
-2023-02-03T11:05:09.361Z,37.2003,36.4998,10,4.2,mb,39,137,0.568,0.64,us,us6000jl5l,2023-02-12T07:23:30.040Z,"Central Turkey",earthquake,4.01,1.924,0.132,16,reviewed,us,us
-2023-02-02T23:32:44.208Z,51.4707,179.4911,60,2.7,ml,,,,0.46,ak,ak0231iymdj8,2023-02-13T22:55:03.110Z,"271 km W of Adak, Alaska",earthquake,,0.9,,,reviewed,ak,ak
-2023-02-02T10:39:55.261Z,26.6426,129.5647,14.839,4.3,mb,31,90,1.171,1.02,us,us6000jms1,2023-02-10T09:35:13.040Z,"157 km E of Nago, Japan",earthquake,4.95,4.842,0.177,9,reviewed,us,us
-2023-02-02T05:54:34.708Z,51.6836,178.7375,70.9,2.8,ml,,,,0.55,ak,ak0231io19pv,2023-02-13T15:30:40.717Z,"Rat Islands, Aleutian Islands, Alaska",earthquake,,0.8,,,reviewed,ak,ak
-2023-02-02T03:44:27.121Z,26.9957,65.8887,38.231,4,mb,19,117,8.951,0.63,us,us6000jkwt,2023-02-03T01:28:35.040Z,"95 km NNW of Bela, Pakistan",earthquake,10.37,8.574,0.163,10,reviewed,us,us
-2023-02-02T02:57:19.004Z,43.3834,146.0437,94.835,4.4,mb,40,179,2.529,0.38,us,us6000jkwl,2023-02-02T04:53:50.040Z,"38 km E of Nemuro, Japan",earthquake,11.81,9.38,0.098,30,reviewed,us,us
-2023-02-02T02:08:25.426Z,40.9772,78.6583,17.625,4.3,mb,28,150,0.989,0.86,us,us6000jkwe,2023-02-03T01:04:04.040Z,"124 km W of Aykol, China",earthquake,7.62,6.556,0.133,16,reviewed,us,us
-2023-02-02T01:04:51.682Z,19.9884,94.1371,35,4.5,mb,25,163,1.894,0.71,us,us6000jkwa,2023-02-03T00:38:31.040Z,"Myanmar",earthquake,4.62,1.973,0.139,15,reviewed,us,us
-2023-02-01T22:23:48.938Z,50.1742,179.6336,29.2,3,ml,,,,0.66,ak,ak0231hafocq,2023-02-16T01:33:01.662Z,"Rat Islands, Aleutian Islands, Alaska",earthquake,,17.8,,,reviewed,ak,ak
-2023-02-01T17:55:30.941Z,18.6718,145.4838,328.722,3.9,mb,33,127,18.92,0.84,us,us6000jmie,2023-02-09T19:35:54.040Z,"Pagan region, Northern Mariana Islands",earthquake,15.78,3.769,0.107,23,reviewed,us,us
-2023-02-01T14:29:54.434Z,36.2134,68.7622,68.989,4,mb,15,116,1.685,0.21,us,us6000jkru,2023-02-08T08:27:13.040Z,"10 km NNE of Baghl?n, Afghanistan",earthquake,9.56,8.149,0.157,11,reviewed,us,us
-2023-02-01T10:53:21.381Z,40.1361,22.8003,15.031,4.6,mb,41,61,1.17,0.77,us,us6000jkpt,2023-02-15T06:09:54.136Z,"22 km ENE of Leptokaryá, Greece",earthquake,3.97,4.566,0.223,6,reviewed,us,us
-2023-01-31T13:52:05.961Z,51.6262,178.6652,73.436,3.1,ml,22,171,0.335,0.38,us,us6000jn0b,2023-02-14T18:07:13.040Z,"Rat Islands, Aleutian Islands, Alaska",earthquake,12.9,15.423,,,reviewed,us,ak
-2023-01-31T13:04:59.899Z,52.0084,178.4763,119.87,3.1,ml,19,161,0.046,0.45,us,us6000jmae,2023-02-14T17:31:28.040Z,"",earthquake,15.12,5.012,0.091,16,reviewed,us,us
-2023-01-31T08:49:57.551Z,19.8499,121.3855,21.758,4.6,mb,48,68,2.967,0.56,us,us6000jkhu,2023-02-02T04:52:06.376Z,"Babuyan Islands region, Philippines",earthquake,9.25,5.459,0.088,39,reviewed,us,us
-2023-01-31T05:25:36.821Z,50.1156,142.4599,10,4.5,mb,77,109,3.166,0.37,us,us6000jkh7,2023-02-12T06:27:23.040Z,"49 km NNW of Smirnykh, Russia",earthquake,8.58,1.859,0.061,77,reviewed,us,us
-2023-01-31T04:49:05.673Z,24.5762,94.4176,64.505,4.6,mb,63,77,4.494,0.77,us,us6000jkh1,2023-02-01T02:32:43.391Z,"35 km E of W?ngjing, India",earthquake,8.77,4.391,0.054,101,reviewed,us,us
-2023-01-31T04:13:04.960Z,38.5432,44.878,10,4,mb,26,82,1.447,0.7,us,us6000jkgv,2023-02-06T13:53:38.768Z,"6 km W of Khowy, Iran",earthquake,5.64,1.89,0.156,11,reviewed,us,us
-2023-01-31T00:43:16.360Z,34.8399,14.2541,10,4.6,mb,91,77,5.293,0.64,us,us6000jkfs,2023-02-01T19:18:42.728Z,"111 km S of ?urrieq, Malta",earthquake,8.74,1.878,0.059,85,reviewed,us,us
+2023-02-06T01:36:27.357Z,36.9921,36.6832,10,5.6,mb,167,47,0.458,0.59,us,us6000jlm9,2023-02-15T04:12:06.711Z,Turkey-Syria border region,earthquake,6.2,1.76,0.052,128,reviewed,us,us
+2023-02-06T01:28:15.984Z,37.1784,36.9468,10.708,6.7,mww,192,19,0.21,0.57,us,us6000jlm1,2023-02-17T18:05:47.295Z,Central Turkey,earthquake,8.97,3.408,0.098,10,reviewed,us,us
+2023-02-06T01:26:50.760Z,37.2241,36.9749,10,5.7,mb,97,75,0.194,1.33,us,us6000jlnn,2023-02-15T03:13:13.851Z,,earthquake,5.4,1.828,0.072,69,reviewed,us,us
+2023-02-06T01:17:35.525Z,37.1662,37.0421,17.943,7.8,mww,216,17,0.134,0.67,us,us6000jllz,2023-02-17T20:33:16.918Z,"27 km E of Nurda??, Turkey",earthquake,6.27,3.278,0.05,38,reviewed,us,us
 2023-01-30T19:55:25.578Z,34.9149,14.2785,9.264,5.3,mww,135,35,2.55,0.67,us,us6000jkea,2023-02-13T21:19:59.960Z,"103 km S of ?urrieq, Malta",earthquake,5.23,3.242,0.039,62,reviewed,us,us
-2023-01-30T19:15:43.959Z,37.8418,142.1019,29.746,4.5,mb,66,135,3.052,1.02,us,us6000jke4,2023-02-13T20:53:54.041Z,"94 km SE of Ishinomaki, Japan",earthquake,7.96,5.687,0.099,30,reviewed,us,us
-2023-01-30T17:07:44.524Z,35.7547,79.8515,10,5,mww,138,38,6.176,0.91,us,us6000jkdb,2023-02-13T20:19:06.040Z,"150 km S of Hotan, China",earthquake,6.58,1.616,0.098,10,reviewed,us,us
-2023-01-30T10:25:12.740Z,23.2239,123.9085,10,5.1,mb,72,84,1.485,1.12,us,us6000jkac,2023-01-30T14:05:33.040Z,"southwestern Ryukyu Islands, Japan",earthquake,7.22,1.802,0.048,143,reviewed,us,us
-2023-01-30T01:02:31.970Z,34.8411,14.3119,10,4.2,mb,46,116,2.623,0.89,us,us6000jk8a,2023-02-16T00:25:37.040Z,"110 km S of ?urrieq, Malta",earthquake,8.7,1.875,0.089,35,reviewed,us,us
-2023-01-30T00:32:10.301Z,36.3618,139.8797,79.539,4.3,mb,33,93,1.359,0.59,us,us6000jk87,2023-02-16T23:36:35.040Z,"6 km N of Y?ki, Japan",earthquake,6.65,7.853,0.201,7,reviewed,us,us
-2023-01-29T23:49:38.212Z,40.0166,82.3702,28,5.7,mww,132,21,3.861,0.52,us,us6000jk82,2023-02-15T05:39:54.884Z,"110 km ESE of Aral, China",earthquake,7.11,1.786,0.078,16,reviewed,us,us
-2023-01-29T22:17:34.028Z,43.2091,136.129,348.535,3.9,mb,73,41,3.161,0.5,us,us6000jk7l,2023-02-15T04:41:17.040Z,"90 km SE of Ol’ga, Russia",earthquake,8.07,6.774,0.057,81,reviewed,us,us
-2023-01-29T22:05:21.293Z,60.0856,156.3615,10,4.1,mb,37,95,2.869,0.3,us,us6000jmxq,2023-02-15T04:20:45.040Z,"231 km WNW of Palana, Russia",earthquake,7.39,1.855,0.123,18,reviewed,us,us
-2023-01-29T22:00:19.418Z,38.5153,44.8139,10,4.2,mb,59,126,1.394,0.64,us,us6000jk7j,2023-02-15T04:10:43.040Z,"12 km WSW of Khowy, Iran",earthquake,6.37,1.871,0.105,25,reviewed,us,us
-2023-01-29T16:38:48.697Z,38.573,44.5857,10,4.1,mb,17,179,1.227,1.22,us,us6000jk6h,2023-01-29T17:38:15.040Z,"32 km W of Khowy, Iran",earthquake,8.94,1.923,0.13,16,reviewed,us,us
-2023-01-29T16:12:38.696Z,35.7754,35.7382,10,4.3,mb,27,132,1.83,1.18,us,us6000jk69,2023-01-29T19:57:39.912Z,"27 km N of Latakia, Syria",earthquake,5.77,1.952,0.119,20,reviewed,us,us
-2023-01-29T15:13:24.819Z,38.41,44.8049,10,4.5,mb,35,152,1.376,0.96,us,us6000jk61,2023-01-29T17:12:30.040Z,"20 km SW of Khowy, Iran",earthquake,8.16,1.937,0.077,50,reviewed,us,us
-2023-01-29T14:41:14.634Z,38.5096,44.7975,10,4.7,mb,32,146,1.38,1.07,us,us6000jk5x,2023-01-29T17:05:44.040Z,"14 km WSW of Khowy, Iran",earthquake,6.5,1.92,0.072,59,reviewed,us,us
-2023-01-29T12:19:47.177Z,35.3532,139.2937,146.936,4.7,mb,96,117,1.134,0.82,us,us6000jk5m,2023-02-12T06:12:23.519Z,"4 km NNW of ?iso, Japan",earthquake,6.01,5.769,0.034,263,reviewed,us,us
-2023-01-29T07:54:47.324Z,33.5209,72.9093,32.385,4.4,mb,33,177,0.327,0.49,us,us6000jk4q,2023-01-29T17:13:36.642Z,"15 km WSW of Rawalpindi, Pakistan",earthquake,11.02,6.721,0.138,15,reviewed,us,us
-2023-01-29T05:09:11.837Z,37.5536,20.9672,33.923,4.3,mb,69,67,0.85,0.54,us,us6000jk3z,2023-01-29T05:56:36.667Z,"22 km SSE of Lithakiá, Greece",earthquake,6.8,5.39,0.099,29,reviewed,us,us
-2023-01-29T03:48:10.405Z,38.6464,44.8532,10,4.1,mb,17,127,1.502,0.79,us,us6000jk3l,2023-01-29T04:10:42.040Z,"13 km NW of Khowy, Iran",earthquake,8.22,1.956,0.175,9,reviewed,us,us
-2023-01-28T22:59:48.937Z,30.0471,142.1496,10,4.4,mb,64,67,2.941,0.52,us,us6000jmwk,2023-02-13T22:18:22.040Z,"Izu Islands, Japan region",earthquake,8.12,1.811,0.083,42,reviewed,us,us
-2023-01-28T20:09:59.211Z,38.6005,44.8287,10,4.5,mb,46,128,1.419,0.73,us,us6000jk1j,2023-02-17T00:50:46.040Z,"12 km WNW of Khowy, Iran",earthquake,6.48,1.851,0.086,39,reviewed,us,us
 2023-01-28T18:14:45.863Z,38.4239,44.9091,16,5.9,mww,235,31,1.459,0.75,us,us6000jk0t,2023-02-04T04:28:47.132Z,"14 km SSW of Khowy, Iran",earthquake,4.81,1.793,0.045,48,reviewed,us,us
-2023-01-28T17:35:55.248Z,52.2371,157.3806,140.436,4.7,mb,46,137,0.894,0.75,us,us6000jk0q,2023-01-28T18:05:42.040Z,"",earthquake,9.72,6.219,0.037,223,reviewed,us,us
-2023-01-28T13:53:09.671Z,33.5453,45.6996,10,4.6,mb,40,112,4.04,0.63,us,us6000jjzp,2023-01-28T16:32:27.040Z,"26 km SSE of Mandal?, Iraq",earthquake,10.05,1.798,0.07,62,reviewed,us,us
-2023-01-28T05:32:50.156Z,44.2129,12.3668,6.196,4.2,mwr,75,32,0.956,0.67,us,us6000jjxr,2023-02-11T06:32:59.703Z,"2 km WNW of Cesenatico, Italy",earthquake,1.82,5.09,0.062,25,reviewed,us,us
-2023-01-28T04:08:56.266Z,18.959,145.3201,235.314,4,mb,30,132,5.357,0.56,us,us6000jmvv,2023-02-10T03:43:59.040Z,"Pagan region, Northern Mariana Islands",earthquake,12.04,9.313,0.144,13,reviewed,us,us
-2023-01-28T01:08:04.554Z,36.4986,71.3233,92.65,4.3,mb,21,108,2.697,0.65,us,us6000jjw9,2023-02-17T00:14:32.040Z,"Afghanistan-Tajikistan-Pakistan region",earthquake,5.52,15.325,0.187,8,reviewed,us,us
-2023-01-27T23:55:09.428Z,51.7311,178.3697,74.081,3.2,ml,18,171,0.235,0.33,us,us6000jn0u,2023-02-14T06:23:03.040Z,"Rat Islands, Aleutian Islands, Alaska",earthquake,5.75,5.423,0.091,16,reviewed,us,us
-2023-01-27T20:43:55.136Z,50.1015,156.3272,72.231,4.4,mb,105,84,3.13,0.66,us,us6000jjtx,2023-01-28T17:47:38.040Z,"65 km SSE of Severo-Kuril’sk, Russia",earthquake,9.79,6.99,0.06,90,reviewed,us,us
-2023-01-27T19:06:14.481Z,39.6384,74.8084,43.917,4.4,mb,60,50,1.544,0.97,us,us6000jjt4,2023-01-27T22:28:41.040Z,"103 km W of Kashgar, China",earthquake,5.81,6.795,0.091,39,reviewed,us,us
-2023-01-27T09:36:37.331Z,30.5496,50.3913,10,4.4,mb,62,80,7.594,0.57,us,us6000jjmx,2023-01-27T11:10:06.040Z,"",earthquake,8.75,1.875,0.086,39,reviewed,us,us
-2023-01-27T09:02:10.633Z,51.712,179.9702,10,2.8,ml,12,147,0.264,0.31,us,us6000jjv5,2023-02-11T01:45:15.592Z,"Rat Islands, Aleutian Islands, Alaska",earthquake,1.57,1.984,0.105,12,reviewed,us,us
-2023-01-27T06:19:30.469Z,29.3398,51.2867,10,4,mb,17,91,6.192,0.51,us,us6000jm0s,2023-02-09T07:53:04.040Z,"10 km NE of Bor?zj?n, Iran",earthquake,8.03,1.882,0.232,5,reviewed,us,us
-2023-01-27T06:03:43.600Z,37.8662,141.6833,59.34,4.2,mb,32,145,2.959,1.17,us,us6000jjm9,2023-02-09T07:43:11.040Z,"69 km SSE of Ishinomaki, Japan",earthquake,9.37,5.595,0.153,12,reviewed,us,us
-2023-01-27T04:31:50.268Z,48.1713,154.6661,40.397,4.3,mb,25,138,5.306,0.57,us,us6000jltp,2023-02-07T23:28:33.040Z,"297 km SSW of Severo-Kuril’sk, Russia",earthquake,10.71,8.479,0.201,7,reviewed,us,us
-2023-01-27T00:10:43.170Z,41.433,77.4528,10,4.6,mb,55,74,0.397,0.5,us,us6000jjkp,2023-02-14T05:55:21.488Z,"81 km SSE of Kadzhi-Say, Kyrgyzstan",earthquake,4.74,1.867,0.103,28,reviewed,us,us
-2023-01-26T23:38:14.307Z,36.6217,67.6255,10,4,mb,27,129,2.311,0.71,us,us6000jjkl,2023-02-14T05:43:31.040Z,"Central Afghanistan",earthquake,7.61,1.973,0.211,6,reviewed,us,us
-2023-01-26T21:41:29.835Z,53.0142,159.5412,58.815,4.3,mb,21,197,0.539,0.41,us,us6000jm0a,2023-02-14T06:09:45.040Z,"61 km E of Petropavlovsk-Kamchatsky, Russia",earthquake,15.3,9.642,0.2,7,reviewed,us,us
-2023-01-26T16:04:56.294Z,30.5315,137.5483,480.991,4.5,mb,141,44,3.218,0.51,us,us6000jjgm,2023-01-26T16:27:07.040Z,"Izu Islands, Japan region",earthquake,9.43,7.3,0.05,118,reviewed,us,us
-2023-01-26T13:56:50.123Z,23.2115,123.3863,10,4.9,mb,47,108,1.296,0.99,us,us6000jjfs,2023-01-26T14:28:00.040Z,"144 km SSE of Yonakuni, Japan",earthquake,7.31,1.899,0.058,94,reviewed,us,us
-2023-01-26T02:28:04.347Z,29.7988,102.472,48.201,4.3,mb,17,68,6.107,0.86,us,us6000jltw,2023-02-14T04:35:47.040Z,"54 km ESE of Kangding, China",earthquake,9.76,7.156,0.168,10,reviewed,us,us
-2023-01-26T01:59:58.723Z,25.7328,90.4362,36.679,4,mb,16,162,5.049,0.68,us,us6000jltv,2023-02-14T03:17:52.040Z,"33 km NE of Tura, India",earthquake,11.33,10.031,0.15,12,reviewed,us,us
-2023-01-26T01:41:56.597Z,36.0852,70.2338,125.544,4.1,mb,25,79,1.823,0.87,us,us6000jjb5,2023-02-14T00:58:33.040Z,"63 km SSE of Farkh?r, Afghanistan",earthquake,4.31,12.124,0.174,9,reviewed,us,us
-2023-01-25T23:21:33.314Z,29.6904,102.0311,10,4.9,mb,135,28,6.5,0.64,us,us6000jjai,2023-02-09T00:20:20.040Z,"35 km SSE of Kangding, China",earthquake,7.1,1.848,0.056,100,reviewed,us,us
-2023-01-25T22:27:31.357Z,20.211,146.2083,35,4.7,mb,91,101,14.06,0.52,us,us6000jja4,2023-02-15T04:36:51.040Z,"Mariana Islands region",earthquake,11.53,1.884,0.067,68,reviewed,us,us
-2023-01-25T21:53:05.320Z,37.4946,72.2706,189.559,4,mb,35,124,2.014,0.33,us,us6000jj9h,2023-02-15T04:48:28.040Z,"60 km N of Khand?d, Afghanistan",earthquake,7.42,6.251,0.138,14,reviewed,us,us
-2023-01-25T21:51:30.264Z,34.8025,14.2155,10.001,4.1,mb,41,80,2.663,0.87,us,us6000jlyt,2023-02-15T05:06:55.040Z,"116 km SSW of ?urrieq, Malta",earthquake,7.19,2.559,0.145,13,reviewed,us,us
-2023-01-25T21:19:08.863Z,29.7831,102.0678,10,4.4,mb,65,76,6.458,0.59,us,us6000jj9c,2023-02-14T06:25:06.040Z,"Western Sichuan, China",earthquake,5.8,1.884,0.083,42,reviewed,us,us
-2023-01-25T20:57:21.308Z,29.5809,102.1701,10,4.3,mb,38,77,6.395,0.8,us,us6000jj97,2023-02-09T15:55:42.040Z,"Western Sichuan, China",earthquake,6.87,1.882,0.116,21,reviewed,us,us
-2023-01-25T20:51:10.100Z,29.6462,102.1105,10,4.4,mb,54,57,6.432,0.66,us,us6000jj94,2023-02-09T15:30:17.040Z,"42 km SSE of Kangding, China",earthquake,7.67,1.871,0.093,33,reviewed,us,us
-2023-01-25T20:30:44.661Z,29.6184,102.0221,10,4.4,mb,31,76,6.517,1.12,us,us6000jj99,2023-02-09T15:05:36.040Z,"43 km S of Kangding, China",earthquake,10.37,1.903,0.134,16,reviewed,us,us
-2023-01-25T19:49:44.478Z,29.729,101.9928,7,5.4,mww,127,20,6.529,0.83,us,us6000jj8s,2023-02-08T19:34:43.974Z,"30 km S of Kangding, China",earthquake,7.06,1.738,0.06,27,reviewed,us,us
-2023-01-25T16:10:48.554Z,35.6956,80.0682,10,4.4,mb,65,102,5.962,0.51,us,us6000jlyc,2023-02-14T05:44:13.040Z,"157 km S of Hotan, China",earthquake,7.2,1.9,0.091,35,reviewed,us,us
-2023-01-25T16:02:10.186Z,35.7331,79.8502,10,5,mww,206,32,5.806,0.5,us,us6000jj6p,2023-02-14T05:11:44.206Z,"152 km S of Hotan, China",earthquake,8.32,1.746,0.086,13,reviewed,us,us
-2023-01-25T15:48:15.733Z,19.0481,144.6581,10,4.8,mb,71,38,17.506,0.5,us,us6000jlwu,2023-02-14T04:20:25.040Z,"Maug Islands region, Northern Mariana Islands",earthquake,12.55,1.839,0.081,47,reviewed,us,us
-2023-01-25T13:48:26.826Z,44.9052,80.9957,10,4.1,mb,20,189,1.916,0.72,us,us6000jj63,2023-01-27T15:33:14.040Z,"Kazakhstan-Xinjiang border region",earthquake,5.16,1.991,0.369,2,reviewed,us,us
-2023-01-25T13:13:38.222Z,41.2102,84.2142,10,4.6,mb,33,102,4.098,0.68,us,us6000jj5y,2023-01-27T15:08:46.040Z,"121 km ESE of Kuqa, China",earthquake,9.05,1.934,0.164,11,reviewed,us,us
 2023-01-25T12:37:05.134Z,35.7086,28.4965,29.59,5.9,mww,163,34,0.589,0.64,us,us6000jj5k,2023-02-08T14:08:40.038Z,"60 km SE of Lárdos, Greece",earthquake,6.96,3.455,0.049,40,reviewed,us,us
-2023-01-25T03:57:50.755Z,56.1588,114.1836,10,4,mb,26,51,3.628,0.33,us,us6000jj2v,2023-02-13T23:10:08.040Z,"47 km E of Severomuysk, Russia",earthquake,7.02,1.91,0.183,8,reviewed,us,us
-2023-01-25T01:44:09.371Z,47.0284,154.2752,10,4.6,mb,16,169,6.472,0.44,us,us6000jlyy,2023-02-13T05:37:48.040Z,"",earthquake,13.19,1.965,0.164,11,reviewed,us,us
-2023-01-25T01:12:51.970Z,34.8866,14.2409,10,4.1,mb,43,156,2.579,0.69,us,us6000jj2f,2023-02-13T03:28:58.155Z,"central Mediterranean Sea",earthquake,8.68,1.924,0.151,12,reviewed,us,us
-2023-01-25T01:00:49.517Z,37.5889,141.6868,51.252,4.8,mwr,107,54,2.972,0.62,us,us6000jj1u,2023-02-13T03:15:47.380Z,"61 km E of Namie, Japan",earthquake,7.14,4.478,0.073,18,reviewed,us,us
-2023-01-24T22:54:58.475Z,27.9386,139.4243,513.977,4.5,mb,158,56,2.591,0.5,us,us6000jj1l,2023-02-14T02:10:09.040Z,"Bonin Islands, Japan region",earthquake,10.1,5.492,0.048,129,reviewed,us,us
-2023-01-24T22:10:34.707Z,34.6292,14.297,10.035,4,mb,16,208,2.834,0.54,us,us6000jlvt,2023-02-14T01:36:15.040Z,"134 km S of ?urrieq, Malta",earthquake,11.2,8.296,0.299,3,reviewed,us,us
-2023-01-24T21:42:41.495Z,34.8739,14.1847,9.34,4,mb,26,207,4.049,0.49,us,us6000jlvs,2023-02-14T01:25:21.040Z,"109 km SSW of ?urrieq, Malta",earthquake,11.19,6.199,0.156,11,reviewed,us,us
-2023-01-24T20:25:34.729Z,34.8994,14.3274,10,5.3,mww,127,70,5.221,0.57,us,us6000jj05,2023-01-30T20:27:36.641Z,"central Mediterranean Sea",earthquake,8.2,1.842,0.036,76,reviewed,us,us
-2023-01-24T15:57:08.430Z,50.073,142.51,10,4.5,mb,95,102,3.121,0.61,us,us6000jixw,2023-02-09T22:11:48.040Z,"Sakhalin, Russia",earthquake,7.81,1.804,0.068,63,reviewed,us,us
-2023-01-24T11:57:52.254Z,52.532,160.2688,35,4.4,mb,30,167,1.1,0.61,us,us6000jiw2,2023-01-24T12:22:09.040Z,"",earthquake,10.51,1.987,0.12,20,reviewed,us,us
-2023-01-24T08:58:32.284Z,29.5974,81.6522,25.227,5.6,mb,105,39,3.655,0.64,us,us6000jivm,2023-01-27T04:20:40.414Z,"62 km NW of Jumla, Nepal",earthquake,7.92,4.58,0.036,266,reviewed,us,us
-2023-01-24T05:59:29.165Z,35.1548,31.2583,10,4.1,mb,33,73,1.711,0.78,us,us6000jlus,2023-02-10T07:04:43.040Z,"Cyprus region",earthquake,6.22,1.926,0.174,9,reviewed,us,us
-2023-01-24T02:11:36.855Z,45.8451,143.2251,332.784,4.1,mb,66,124,1.159,0.61,us,us6000jitp,2023-02-07T04:01:43.040Z,"94 km SSE of Korsakov, Russia",earthquake,9.01,6.123,0.045,133,reviewed,us,us
-2023-01-23T13:42:02.771Z,24.8836,93.079,10,5.1,mb,110,42,2.561,0.91,us,us7000j6c8,2023-02-06T22:41:39.139Z,"12 km NE of Lakhipur, India",earthquake,6.02,1.551,0.042,184,reviewed,us,us
+2023-01-24T20:25:34.729Z,34.8994,14.3274,10,5.3,mww,127,70,5.221,0.57,us,us6000jj05,2023-01-30T20:27:36.641Z,central Mediterranean Sea,earthquake,8.2,1.842,0.036,76,reviewed,us,us
 2023-01-23T10:37:52.930Z,35.0331,14.1929,10,5.1,mww,101,46,5.117,1.15,us,us7000j6bz,2023-01-24T21:04:27.493Z,"92 km SSW of Qrendi, Malta",earthquake,2.44,1.834,0.045,48,reviewed,us,us
-2023-01-23T04:35:06.098Z,24.1693,125.2957,27.626,4.2,mwr,84,95,2.105,0.87,us,us7000j6b4,2023-02-09T06:04:24.040Z,"70 km S of Hirara, Japan",earthquake,7.67,5.737,0.062,25,reviewed,us,us
-2023-01-23T02:59:43.591Z,23.4481,142.9353,44.85,5.2,mb,195,37,10.016,0.77,us,us7000j6at,2023-02-09T01:52:39.040Z,"Volcano Islands, Japan region",earthquake,9.38,4.916,0.046,157,reviewed,us,us
-2023-01-22T22:08:26.786Z,38.5293,99.0858,11.284,4.2,mb,37,50,10.717,0.36,us,us7000j6a5,2023-01-30T23:21:47.040Z,"126 km WSW of Zhangye, China",earthquake,10.11,5.149,0.131,16,reviewed,us,us
-2023-01-22T21:22:37.602Z,36.5949,70.8744,214.022,4.4,mb,20,97,2.536,0.73,us,us7000j6a0,2023-01-30T22:00:15.040Z,"30 km S of Jurm, Afghanistan",earthquake,8.11,10.761,0.311,3,reviewed,us,us
-2023-01-22T13:16:21.809Z,42.5955,146.6294,22.831,4.4,mb,17,154,2.64,0.76,us,us7000j698,2023-02-03T17:33:38.040Z,"118 km SE of Nemuro, Japan",earthquake,10.93,6.492,0.241,7,reviewed,us,us
-2023-01-22T07:03:21.769Z,38.2784,73.9512,159.555,4.1,mb,40,129,2.063,0.64,us,us7000j66s,2023-02-16T12:58:56.040Z,"12 km N of Murghob, Tajikistan",earthquake,7.24,8.247,0.127,18,reviewed,us,us
-2023-01-22T05:40:19.304Z,37.3503,71.881,138.674,4.3,mb,24,80,2.125,0.48,us,us7000j66f,2023-02-16T14:05:16.040Z,"32 km ESE of Khorugh, Tajikistan",earthquake,3.65,11.951,0.265,4,reviewed,us,us
-2023-01-22T04:46:46.879Z,38.8689,22.9378,10,4.6,mb,72,47,0.493,0.76,us,us7000j667,2023-02-16T23:14:45.979Z,"9 km W of Aidipsós, Greece",earthquake,3.26,1.818,0.098,31,reviewed,us,us
-2023-01-22T03:25:47.266Z,19.0186,145.6631,126.302,4.1,mb,23,161,5.452,0.69,us,us6000jkb1,2023-02-02T03:08:10.040Z,"Maug Islands region, Northern Mariana Islands",earthquake,14.74,9.484,0.158,13,reviewed,us,us
-2023-01-22T01:58:59.676Z,28.2639,130.0506,29.821,4.3,mb,27,125,2.125,0.74,us,us6000jkax,2023-02-02T01:56:49.040Z,"Ryukyu Islands, Japan",earthquake,6.95,5.959,0.177,9,reviewed,us,us
-2023-01-21T13:31:57.963Z,34.7103,36.3823,10,4.3,mb,28,187,2.522,1.1,us,us7000j62n,2023-02-12T20:06:53.976Z,"12 km ENE of Tallkalakh, Syria",earthquake,7.85,1.939,0.187,8,reviewed,us,us
-2023-01-21T13:26:03.753Z,18.3191,145.7963,153.639,4.8,mb,66,84,4.787,0.92,us,us7000j62k,2023-02-12T20:01:02.040Z,"",earthquake,11.1,7.374,0.038,220,reviewed,us,us
-2023-01-21T11:14:29.784Z,37.1807,141.5525,44.118,4.3,mb,40,142,2.756,0.53,us,us7000j623,2023-02-15T13:13:38.040Z,"59 km SE of Namie, Japan",earthquake,8.02,4.348,0.107,28,reviewed,us,us
-2023-01-20T18:05:41.219Z,37.7473,141.566,61.691,4.5,mb,148,98,2.94,0.56,us,us7000j5vu,2023-02-15T21:36:22.454Z,"57 km ENE of Namie, Japan",earthquake,7.32,6.008,0.051,122,reviewed,us,us
-2023-01-20T16:41:12.155Z,44.943,148.0752,10.628,4.1,mb,14,175,4.006,0.38,us,us6000jjpe,2023-01-27T21:21:51.040Z,"35 km SSE of Kuril’sk, Russia",earthquake,11.43,5.225,0.233,5,reviewed,us,us
-2023-01-20T12:41:42.991Z,34.4397,141.7096,10,4.3,mb,24,144,2.059,0.31,us,us7000j5t0,2023-02-05T06:22:04.040Z,"149 km ESE of Katsuura, Japan",earthquake,8.35,1.847,0.188,8,reviewed,us,us
-2023-01-20T05:48:28.582Z,38.9239,142.1003,47.894,5,mb,187,128,2.027,0.85,us,us7000j5pu,2023-01-29T07:02:08.250Z,"37 km ESE of ?funato, Japan",earthquake,7.73,6.169,0.044,164,reviewed,us,us
-2023-01-20T05:37:23.862Z,36.089,31.6537,87.455,4.2,mb,43,144,1.554,0.42,us,us7000j5ps,2023-01-29T06:53:34.040Z,"58 km SSW of Türkler, Turkey",earthquake,6.72,8.777,0.132,16,reviewed,us,us
-2023-01-20T03:46:05.920Z,39.054,70.6926,12.863,4.7,mb,50,158,0.958,0.7,us,us7000j5pg,2023-02-10T01:03:47.040Z,"Kyrgyzstan-Tajikistan border region",earthquake,5.18,1.263,0.07,63,reviewed,us,us
-2023-01-20T01:20:11.002Z,35.4553,80.4047,10,4.3,mb,21,246,6.157,0.98,us,us7000j5nn,2023-02-10T00:38:40.040Z,"188 km SSE of Hotan, China",earthquake,10.51,1.988,0.216,6,reviewed,us,us
-2023-01-20T00:29:25.301Z,32.7149,23.4375,10,4.1,mb,44,174,4.623,0.6,us,us7000j5ne,2023-02-07T02:35:58.040Z,"75 km E of Darnah, Libya",earthquake,6.01,1.956,0.106,24,reviewed,us,us
-2023-01-19T18:26:36.191Z,19.0326,145.3722,234.493,3.9,mb,26,133,5.434,0.56,us,us6000jjhx,2023-02-01T14:50:31.040Z,"Maug Islands region, Northern Mariana Islands",earthquake,14.39,9.34,0.154,11,reviewed,us,us
-2023-01-19T15:20:19.506Z,52.8221,152.9171,509.445,4.4,mb,196,94,2.906,0.62,us,us7000j5im,2023-02-15T18:10:18.040Z,"286 km WNW of Ozernovskiy, Russia",earthquake,10.47,6.076,0.038,210,reviewed,us,us
-2023-01-19T12:24:41.046Z,41.3097,142.5275,43.544,4.3,mb,41,141,0.848,0.57,us,us7000j5hp,2023-02-14T15:13:41.040Z,"109 km E of Mutsu, Japan",earthquake,4.22,7.775,0.129,17,reviewed,us,us
-2023-01-19T11:30:42.703Z,35.5568,71.4043,100.683,5.1,mww,115,46,2.186,0.67,us,us7000j5hh,2023-02-14T11:41:05.676Z,"Afghanistan-Pakistan border region",earthquake,3.67,4.444,0.08,15,reviewed,us,us
-2023-01-19T06:18:48.348Z,34.657,14.2292,10.157,4.3,mb,15,220,4.14,0.42,us,us6000jjh2,2023-02-10T11:39:09.040Z,"132 km S of ?urrieq, Malta",earthquake,9.93,6.289,0.307,3,reviewed,us,us
-2023-01-19T05:55:22.616Z,38.5878,44.7612,10,4.3,mb,33,104,1.077,0.45,us,us7000j5f2,2023-02-10T07:56:00.040Z,"17 km WNW of Khowy, Iran",earthquake,5.51,1.915,0.113,22,reviewed,us,us
-2023-01-19T03:25:24.263Z,33.7326,137.2728,14.259,4.5,mb,40,77,1.207,0.66,us,us7000j5ep,2023-01-27T03:59:50.040Z,"near the south coast of Honshu, Japan",earthquake,4.81,4.399,0.14,15,reviewed,us,us
-2023-01-19T02:22:27.212Z,39.4825,25.8279,10,4.3,mwr,96,47,0.932,0.75,us,us7000j5e7,2023-01-27T03:41:40.521Z,"32 km WNW of Míthymna, Greece",earthquake,4.3,1.801,0.078,16,reviewed,us,us
-2023-01-19T01:56:16.933Z,19.8775,120.5851,10,4.3,mb,18,136,2.962,0.47,us,us6000jjgt,2023-01-27T03:37:29.040Z,"147 km N of Pagudpud, Philippines",earthquake,11.84,1.8,0.238,5,reviewed,us,us
-2023-01-19T01:41:39.388Z,25.937,143.0309,10,4.6,mb,49,135,1.381,0.49,us,us7000j5e6,2023-01-27T03:29:21.040Z,"Volcano Islands, Japan region",earthquake,7.44,1.684,0.065,71,reviewed,us,us
-2023-01-19T00:58:43.069Z,36.3005,141.9726,29.911,4.2,mb,20,173,3.045,0.47,us,us6000jjh1,2023-02-07T04:11:05.040Z,"120 km ENE of Hasaki, Japan",earthquake,10.13,8.016,0.215,6,reviewed,us,us
-2023-01-19T00:05:44.556Z,51.8883,178.573,111.312,3.6,mb,62,150,0.068,0.54,us,us6000jjgp,2023-02-07T04:45:15.040Z,"Rat Islands, Aleutian Islands, Alaska",earthquake,10.32,3.929,0.09,31,reviewed,us,us
-2023-01-18T23:42:34.953Z,51.8185,178.2445,115.88,3.7,mb,47,168,0.21,0.7,us,us6000jjf8,2023-02-07T05:06:26.040Z,"Rat Islands, Aleutian Islands, Alaska",earthquake,8.41,5.871,0.099,26,reviewed,us,us
-2023-01-18T19:32:25.565Z,23.473,142.2526,9.141,4.5,mb,35,157,3.608,0.94,us,us6000jjf0,2023-01-30T18:47:31.040Z,"Volcano Islands, Japan region",earthquake,12.54,4.965,0.116,22,reviewed,us,us
-2023-01-18T19:01:06.785Z,43.0811,142.2161,120.209,4.1,mb,35,103,1.073,0.47,us,us6000jjf1,2023-01-30T15:58:42.040Z,"Hokkaido, Japan region",earthquake,7.44,7.277,0.135,15,reviewed,us,us
-2023-01-18T18:22:50.421Z,38.2915,21.8411,10,4.2,mb,45,102,0.825,0.89,us,us7000j5al,2023-01-27T22:11:04.409Z,"2 km NNE of Áno Kastrítsi, Greece",earthquake,3.51,1.644,0.146,13,reviewed,us,us
-2023-01-18T17:00:12.964Z,34.9489,14.1932,10,4.7,mb,76,59,2.518,0.75,us,us7000j59w,2023-02-13T23:01:05.040Z,"101 km SSW of ?urrieq, Malta",earthquake,7.28,0.874,0.078,50,reviewed,us,us
-2023-01-18T15:54:46.261Z,34.8554,14.2579,10,5.1,mww,193,39,2.609,0.57,us,us7000j59j,2023-02-08T01:07:27.302Z,"central Mediterranean Sea",earthquake,2.34,1.814,0.048,41,reviewed,us,us
-2023-01-18T14:55:50.392Z,38.3997,44.9477,10,4.4,mb,74,101,1.225,0.32,us,us7000j59a,2023-02-16T09:35:11.040Z,"16 km S of Khowy, Iran",earthquake,5.99,1.748,0.078,50,reviewed,us,us
-2023-01-18T14:13:03.269Z,34.9715,14.2761,10,4.6,mb,94,101,4.1,0.26,us,us7000j5a4,2023-02-15T21:03:22.482Z,"97 km S of ?urrieq, Malta",earthquake,7.76,1.869,0.077,50,reviewed,us,us
-2023-01-18T14:09:34.227Z,36.492,69.6013,10,4.2,mb,18,104,1.999,1.05,us,us6000jjez,2023-02-16T15:03:16.040Z,"24 km WSW of Farkh?r, Afghanistan",earthquake,7.74,1.945,0.187,8,reviewed,us,us
-2023-01-18T13:30:47.860Z,36.9911,36.1694,10,4.1,mb,15,105,0.851,0.98,us,us6000jjfc,2023-02-16T14:51:47.040Z,"4 km NNW of Erzin, Turkey",earthquake,3.32,1.949,0.371,2,reviewed,us,us
-2023-01-18T10:42:39.023Z,38.472,44.9169,16.66,4.3,mb,25,131,1.158,0.9,us,us7000j574,2023-01-29T06:21:37.040Z,"9 km SSW of Khowy, Iran",earthquake,5.37,2.233,0.13,17,reviewed,us,us
-2023-01-18T10:08:14.083Z,38.4382,44.9433,18.523,5.7,mww,195,59,1.188,0.66,us,us7000j56z,2023-02-15T05:40:57.272Z,"Turkey-Iran border region",earthquake,5.44,3.75,0.069,20,reviewed,us,us
-2023-01-18T04:33:26.564Z,24.7915,124.8538,54.834,4.8,mb,48,119,1.708,0.85,us,us7000j54p,2023-01-27T00:12:51.040Z,"45 km W of Hirara, Japan",earthquake,9.95,7.246,0.07,63,reviewed,us,us
+2023-01-18T15:54:46.261Z,34.8554,14.2579,10,5.1,mww,193,39,2.609,0.57,us,us7000j59j,2023-02-08T01:07:27.302Z,central Mediterranean Sea,earthquake,2.34,1.814,0.048,41,reviewed,us,us
+2023-01-18T10:08:14.083Z,38.4382,44.9433,18.523,5.7,mww,195,59,1.188,0.66,us,us7000j56z,2023-02-15T05:40:57.272Z,Turkey-Iran border region,earthquake,5.44,3.75,0.069,20,reviewed,us,us
 2023-01-18T04:21:57.431Z,34.9044,14.2658,10,5,mb,84,59,4.107,0.57,us,us7000j54l,2023-01-27T00:09:10.026Z,"104 km S of ?urrieq, Malta",earthquake,8.09,1.827,0.045,156,reviewed,us,us
-2023-01-18T03:26:32.922Z,24.7752,125.4156,35,4.6,mb,86,118,2.21,0.71,us,us7000j54d,2023-01-26T23:19:31.040Z,"11 km ESE of Hirara, Japan",earthquake,8.44,1.926,0.077,51,reviewed,us,us
-2023-01-18T01:57:20.960Z,29.6417,101.7166,35,4.5,mb,22,154,6.778,0.54,us,us6000jjdw,2023-01-26T22:36:40.040Z,"46 km SSW of Kangding, China",earthquake,12.32,1.944,0.163,11,reviewed,us,us
+2022-12-28T12:24:21.110Z,38.5834,23.7145,13.137,5,mww,156,44,1.162,0.54,us,us7000j0m2,2023-02-01T13:04:06.040Z,"6 km E of Psachná, Greece",earthquake,5.26,3.185,0.062,25,reviewed,us,us
+2022-12-24T13:24:39.123Z,34.0313,57.1703,10,5.3,mww,75,68,9.094,0.75,us,us6000jbg1,2023-02-04T18:39:13.040Z,Northeastern Iran,earthquake,7.31,1.852,0.075,17,reviewed,us,us
+2022-12-13T14:14:27.412Z,33.9776,57.144,10,5.1,mww,90,63,9.038,0.45,us,us6000j8zz,2023-01-18T20:43:21.040Z,"46 km NNE of Tabas, Iran",earthquake,7.76,1.8,0.068,21,reviewed,us,us
+2022-12-08T06:42:15.112Z,42.236,46.9267,61.331,5.5,mww,172,50,0.954,0.44,us,us6000j7uj,2023-02-11T23:03:15.040Z,"7 km E of Tsurib, Russia",earthquake,6.45,4.633,0.083,14,reviewed,us,us
+2022-11-23T01:08:15.435Z,40.8356,30.9831,10,6.1,mww,286,14,0.399,0.64,us,us7000irp8,2023-02-07T07:10:15.191Z,"15 km W of Düzce, Turkey",earthquake,5.05,1.647,0.052,35,reviewed,us,us
+2022-11-20T23:24:58.462Z,35.8357,26.4319,63,5.5,mww,235,43,1.371,0.76,us,us7000ir86,2023-01-30T06:00:29.040Z,"Crete, Greece",earthquake,5.08,1.857,0.05,39,reviewed,us,us
+2022-11-09T06:07:26.657Z,43.9315,13.3152,8,5.6,mww,147,14,0.881,0.88,us,us7000infp,2023-02-16T07:51:15.850Z,central Italy,earthquake,4.38,0.527,0.032,92,reviewed,us,us
+2022-11-03T04:50:25.095Z,45.5117,26.4901,153.171,5.1,mww,123,17,0.384,0.62,us,us7000im41,2023-01-12T23:11:07.040Z,"6 km ENE of Gura Teghii, Romania",earthquake,6.05,3.296,0.066,22,reviewed,us,us
+2022-10-31T21:42:50.853Z,39.8773,15.6395,271.217,5.5,mww,127,40,0.178,0.6,us,us7000ilkv,2023-01-12T23:10:50.040Z,"12 km WSW of Tortora Marina, Italy",earthquake,5.49,4.096,0.036,75,reviewed,us,us
+2022-10-11T15:48:46.359Z,37.2612,36.2339,10,5,mww,104,38,1.618,0.56,us,us6000isrr,2022-12-17T22:53:54.040Z,"17 km SE of Kadirli, Turkey",earthquake,3.18,1.751,0.045,47,reviewed,us,us
+2022-10-08T22:02:28.782Z,38.3392,22.5785,19.78,5.3,mww,233,14,0.707,0.51,us,us6000is5j,2022-12-17T22:53:43.040Z,"6 km SW of Antikyra, Greece",earthquake,5.08,3.003,0.045,48,reviewed,us,us
+2022-10-05T00:21:29.702Z,38.5064,45.0259,15,5.6,mww,105,67,1.558,0.67,us,us6000iqx6,2022-12-10T22:53:11.040Z,"8 km SE of Khowy, Iran",earthquake,7.72,1.811,0.057,30,reviewed,us,us
+2022-10-02T04:04:01.171Z,34.2663,26.1135,10,5.4,mww,112,43,1.433,0.72,us,us6000iq4q,2022-12-10T22:52:40.040Z,"89 km SSE of Ierápetra, Greece",earthquake,6.03,1.739,0.046,45,reviewed,us,us
+2022-09-27T14:08:32.729Z,40.7188,42.8876,10,5.3,mww,87,38,1.525,0.56,us,us6000inmr,2022-12-03T22:02:29.040Z,"22 km WSW of Susuz, Turkey",earthquake,5.08,1.811,0.047,43,reviewed,us,us
+2022-09-21T17:57:54.724Z,38.4613,44.9496,10,5.1,mww,75,62,1.494,0.92,us,us7000i9z2,2022-11-26T20:57:50.040Z,"9 km S of Khowy, Iran",earthquake,4.74,1.819,0.093,11,reviewed,us,us
+2022-09-08T07:36:23.175Z,37.8942,20.0987,10.482,5.5,mww,163,37,1.618,0.54,us,us6000ii2v,2022-11-15T19:05:48.040Z,"45 km SW of Lixoúri, Greece",earthquake,5.91,3.751,0.037,72,reviewed,us,us
+2022-09-03T04:13:10.932Z,35.0971,26.3465,8.819,5.3,mww,122,25,0.803,0.67,us,us7000i4v6,2022-11-15T19:06:01.040Z,"13 km SE of Palekastro, Greece",earthquake,5.27,3.325,0.045,48,reviewed,us,us
+2022-08-31T10:10:11.426Z,37.5527,26.8515,10.926,5.4,mww,126,34,1.641,0.53,us,us7000i3yp,2022-11-06T04:36:59.040Z,"14 km NW of Megálo Chorió, Greece",earthquake,4.26,4.068,0.041,57,reviewed,us,us
+2022-08-14T03:24:22.958Z,37.9952,27.1512,11.697,5,mww,89,22,1.213,1.05,us,us6000ianw,2022-10-28T02:25:49.040Z,"3 km SE of Özdere, Turkey",earthquake,4.27,3.321,0.098,10,reviewed,us,us
+2022-08-12T21:31:50.429Z,33.5235,19.0439,16.034,5.2,mww,112,43,4.341,0.57,us,us6000iacz,2022-10-21T23:21:09.040Z,"180 km NW of T?krah, Libya",earthquake,7.74,3.267,0.045,48,reviewed,us,us
+2022-06-12T18:35:20.871Z,38.7366,43.5068,10,5.2,mww,67,56,0.55,0.73,us,us7000hgyu,2022-08-21T00:16:32.040Z,"28 km NNE of Van, Turkey",earthquake,4.7,1.9,0.086,13,reviewed,us,us
+2022-06-10T01:40:21.404Z,34.8354,33.8695,47.15,5,mww,115,47,0.46,1.01,us,us7000hgcl,2022-08-13T21:52:43.040Z,"15 km S of Xylofágou, Cyprus",earthquake,4.4,2.1,0.058,29,reviewed,us,us
+2022-04-22T21:07:48.316Z,43.0742,18.1803,10,5.7,mww,,16,1.023,0.9,us,us6000hfqj,2022-11-11T11:22:02.601Z,"15 km NNE of Ljubinje, Bosnia and Herzegovina",earthquake,4.7,1.8,0.039,63,reviewed,us,us
+2022-04-09T14:02:15.496Z,38.1155,38.6617,10,5.3,mww,,55,1.008,0.87,us,us7000h0wh,2022-06-20T22:07:34.040Z,"9 km NNE of Sincik, Turkey",earthquake,4.8,1.8,0.062,25,reviewed,us,us
+2022-02-13T18:25:56.058Z,41.1598,44.01,10,5.3,mww,,29,0.993,0.88,us,us7000gkl5,2022-04-30T14:18:07.040Z,"18 km WSW of Metsavan, Armenia",earthquake,4.6,1.8,0.057,30,reviewed,us,us
+2022-02-02T21:03:48.327Z,35.0634,31.8203,26.39,5.3,mww,,24,1.244,0.68,us,us7000ghf9,2022-04-15T17:57:14.040Z,,earthquake,4.8,3.7,0.049,40,reviewed,us,us
+2022-01-17T11:40:06.817Z,34.9289,63.6208,11.4,5.3,mww,,43,4.482,0.54,us,us7000gclu,2022-04-01T17:40:14.040Z,"45 km E of Qala i Naw, Afghanistan",earthquake,7.2,4.1,0.083,14,reviewed,us,us
+2022-01-16T11:48:05.261Z,40.0413,24.361,7,5.5,mww,,19,1.419,0.52,us,us7000gcfq,2022-04-01T17:40:13.040Z,"25 km SSE of Karyes, Greece",earthquake,5,1.8,0.045,48,reviewed,us,us
+2022-01-11T01:07:48.064Z,35.2267,31.9435,21,6.6,mww,,21,1.168,0.71,us,us7000gaqu,2022-06-08T04:06:23.087Z,"48 km WNW of Pólis, Cyprus",earthquake,4.8,1.7,0.045,47,reviewed,us,us
+2022-01-09T21:43:47.201Z,40.8272,21.3919,13.45,5.5,mww,,19,1.106,0.76,us,us7000gaex,2022-03-19T22:07:33.040Z,"5 km NNW of Flórina, Greece",earthquake,5.5,3,0.033,88,reviewed,us,us
+2022-01-05T03:21:16.251Z,36.1445,31.2928,42.99,5.1,mww,,42,1.268,0.95,us,us7000g94d,2022-03-12T22:19:08.040Z,"67 km SSW of Okurcalar, Turkey",earthquake,5.4,4,0.055,32,reviewed,us,us
+2021-12-29T16:47:08.107Z,34.713,25.1184,64.93,5,mww,,43,0.603,0.93,us,us6000gg5p,2022-03-05T23:10:53.040Z,"Crete, Greece",earthquake,6.5,4.5,0.075,17,reviewed,us,us
+2021-12-29T05:08:09.950Z,34.8334,25.1386,64.53,5.7,mww,,36,0.497,0.79,us,us6000gg0y,2022-03-05T23:10:50.040Z,"19 km S of Pýrgos, Greece",earthquake,5.7,3.2,0.036,73,reviewed,us,us
+2021-12-26T18:59:02.711Z,35.1923,26.9659,10,5.6,mww,,46,0.388,1.09,us,us6000gfhq,2022-03-05T23:10:42.040Z,"25 km S of Fry, Greece",earthquake,5.7,1.8,0.056,31,reviewed,us,us
+2021-12-26T15:15:11.703Z,35.1452,26.8939,10,5.1,mww,,48,0.456,0.72,us,us6000gffm,2022-03-05T23:10:42.040Z,"30 km S of Fry, Greece",earthquake,4.1,1.7,0.062,25,reviewed,us,us
+2021-12-18T05:16:39.702Z,36.0912,23.2437,63.5,5,mww,,57,1.517,0.56,us,us6000gdc8,2022-03-01T16:37:23.040Z,"23 km ESE of Kýthira, Greece",earthquake,6.5,5.4,0.086,13,reviewed,us,us
+2021-12-15T08:21:09.794Z,32.3102,49.693,10,5,mb,,39,4.335,1.06,us,us6000gccv,2022-02-24T21:01:03.040Z,"55 km NE of Masjed Soleym?n, Iran",earthquake,7.5,1.8,0.052,124,reviewed,us,us
+2021-11-30T04:00:40.529Z,37.7371,26.0792,10,5.1,mww,,43,1.481,0.61,us,us6000g7ta,2022-02-05T23:03:28.040Z,"23 km NW of Agios Kirykos, Greece",earthquake,2.6,1.8,0.063,24,reviewed,us,us
+2021-11-20T12:46:06.106Z,40.7299,48.7112,10,5,mww,,37,3.085,0.62,us,us7000fvr9,2022-05-29T19:01:08.630Z,"12 km NNE of Shamakhi, Azerbaijan",earthquake,7.5,1.8,0.086,13,reviewed,us,us
+2021-11-19T12:40:53.461Z,39.8267,41.9223,6.17,5.1,mwr,,34,1.112,0.77,us,us7000fvfl,2022-05-29T19:06:08.046Z,"23 km NW of Karayaz?, Turkey",earthquake,5,4.4,0.078,16,reviewed,us,us
+2021-11-08T17:43:21.856Z,37.8434,32.1713,10,5.1,mww,,22,1.315,0.58,us,us7000fsfm,2022-01-15T20:51:41.040Z,"23 km SE of Derbent, Turkey",earthquake,4.9,1.8,0.05,39,reviewed,us,us
+2021-10-19T05:32:32.741Z,34.576,28.3953,43.86,5.9,mww,,25,1.401,0.52,us,us6000fvtm,2021-12-25T22:58:48.040Z,"149 km SE of Karpathos, Greece",earthquake,5.1,3.9,0.05,38,reviewed,us,us
+2021-10-12T09:24:05.099Z,35.1691,26.2152,20,6.4,mww,,19,0.86,0.46,us,us6000ftxu,2021-12-18T19:58:57.040Z,"4 km SW of Palekastro, Greece",earthquake,6.1,1.8,0.048,42,reviewed,us,us
+2021-10-08T23:16:26.479Z,32.3379,49.7282,10,5.1,mb,,40,4.339,0.96,us,us6000ft57,2021-12-18T19:58:40.040Z,"59 km NE of Masjed Soleym?n, Iran",earthquake,6.1,1.7,0.041,192,reviewed,us,us
+2021-10-04T02:39:28.323Z,32.335,49.7618,13,5.5,mww,,23,4.363,1.02,us,us6000frf2,2021-12-10T21:14:06.040Z,"61 km NE of Masjed Soleym?n, Iran",earthquake,7.2,1.7,0.063,24,reviewed,us,us
+2021-09-28T04:48:08.650Z,35.0817,25.2018,10,5.3,mww,,43,0.328,0.94,us,us7000ff36,2021-12-04T14:30:04.040Z,"9 km SW of Arkalochóri, Greece",earthquake,4.5,1.7,0.046,45,reviewed,us,us
+2021-09-27T06:17:21.478Z,35.244,25.2697,6,6,mww,,19,0.313,0.47,us,us7000fes8,2022-01-08T16:08:44.480Z,"6 km N of Thrapsanón, Greece",earthquake,5,1.8,0.043,51,reviewed,us,us
+2021-09-13T04:02:32.524Z,37.289,58.8939,10,5.1,mb,,39,8.677,0.9,us,us7000fans,2021-11-23T15:11:05.040Z,"39 km ENE of Q?ch?n, Iran",earthquake,7.2,1.8,0.049,135,reviewed,us,us
+2021-08-31T11:04:26.926Z,39.0422,30.1894,10,5.1,mww,,21,0.861,0.49,us,us7000f66b,2021-11-06T20:28:39.040Z,"19 km W of ?hsaniye, Turkey",earthquake,4,1.8,0.059,28,reviewed,us,us
+2021-08-07T01:39:45.606Z,36.2724,27.0356,18.4,5,mww,,45,0.73,1.11,us,us6000f328,2021-10-23T15:45:46.040Z,"38 km SSW of Mandráki, Greece",earthquake,3.8,3.3,0.042,55,reviewed,us,us
+2021-08-03T12:38:17.754Z,36.3902,27.0435,10,5.2,mww,,41,0.846,0.46,us,us6000f1u4,2021-10-14T01:06:20.040Z,"25 km SSW of Mandráki, Greece",earthquake,4.7,1.7,0.052,35,reviewed,us,us
+2021-08-01T04:31:26.956Z,36.3958,27.0112,10.13,5.6,mww,,34,0.855,0.95,us,us6000f155,2021-10-14T01:04:44.040Z,"26 km SSW of Mandráki, Greece",earthquake,4.6,1.3,0.034,85,reviewed,us,us
+2021-06-25T18:28:37.298Z,39.1868,40.1667,3.07,5.4,mww,,34,1.19,0.7,us,us6000epst,2021-11-06T01:14:47.041Z,eastern Turkey,earthquake,4,3.1,0.047,44,reviewed,us,us
+2021-06-21T22:14:13.556Z,36.4391,27.0416,9.03,5.5,mww,,22,0.895,0.77,us,us7000ef1g,2021-08-27T18:58:12.040Z,"20 km SSW of Mandráki, Greece",earthquake,4.6,2.8,0.049,40,reviewed,us,us
+2021-06-06T04:54:23.713Z,33.4017,46.1288,10,5.3,mb,,52,1.744,1.17,us,us7000eab7,2022-08-09T05:24:44.859Z,"31 km N of Mehr?n, Iran",earthquake,5.9,1.8,0.032,334,reviewed,us,us
+2021-05-17T00:54:01.149Z,37.3349,56.7058,7,5.4,mww,,31,5.373,0.79,us,us7000e3n6,2021-07-24T21:07:29.040Z,"57 km WSW of Bojn?rd, Iran",earthquake,7,1.8,0.058,29,reviewed,us,us
+2021-05-16T23:04:56.799Z,37.3033,56.7455,10,5.3,mww,,27,5.33,0.75,us,us7000e3mh,2021-07-24T21:07:27.040Z,"55 km WSW of Bojn?rd, Iran",earthquake,6.9,1.8,0.061,26,reviewed,us,us
+2021-04-17T17:08:00.786Z,36.4064,27.096,9.98,5,mww,,23,0.85,0.63,us,us6000e2f0,2022-08-09T04:39:05.576Z,"22 km S of Mandráki, Greece",earthquake,4.9,2.8,0.052,35,reviewed,us,us
+2021-04-13T20:28:02.233Z,36.5325,27.0593,5.7,5.3,mww,,23,0.914,0.53,us,us6000e1bu,2021-06-19T21:25:27.040Z,"10 km SW of Mandráki, Greece",earthquake,4.1,3.1,0.052,36,reviewed,us,us
+2021-04-06T15:12:25.757Z,35.6618,45.9925,10,5.2,mww,,37,0.427,0.56,us,us6000dzgg,2021-06-12T21:37:48.040Z,"6 km NE of Baynjiwayn, Iraq",earthquake,6.3,1.8,0.059,28,reviewed,us,us
+2021-03-27T13:47:55.267Z,42.4479,16.0496,7,5.5,mww,,30,1.651,0.88,us,us6000dx0m,2021-12-11T13:15:43.423Z,"55 km N of Peschici, Italy",earthquake,4.6,1.8,0.043,53,reviewed,us,us
+2021-03-12T12:57:50.879Z,39.8931,22.0875,7,5.6,mww,,31,0.373,0.49,us,us7000dimf,2021-05-26T22:06:15.040Z,"8 km W of Elassóna, Greece",earthquake,4,1.8,0.043,53,reviewed,us,us
+2021-03-04T19:23:51.987Z,39.8812,21.9795,10,5.5,mb,,20,0.45,0.99,us,us7000dfld,2021-05-13T22:45:31.040Z,"7 km S of Kraniá Elassónas, Greece",earthquake,4.8,1.8,0.028,440,reviewed,us,us
+2021-03-04T18:38:19.386Z,39.7865,22.1157,10,5.8,mb,,19,0.427,0.91,us,us7000dfku,2021-05-13T22:45:28.040Z,"11 km E of Verdikoússa, Greece",earthquake,5.5,1.8,0.036,277,reviewed,us,us
+2021-03-03T18:24:09.041Z,39.7227,22.1153,14.74,5.1,mww,,17,0.476,0.95,us,us7000df7z,2021-05-13T22:42:32.040Z,"11 km NNE of Grizáno, Greece",earthquake,4.3,3.2,0.053,34,reviewed,us,us
+2021-03-03T11:45:46.390Z,39.7259,22.2212,10,5.3,mww,,28,0.429,0.4,us,us7000df4l,2021-05-13T22:42:12.040Z,"5 km WSW of Týrnavos, Greece",earthquake,5.5,1.8,0.071,19,reviewed,us,us
+2021-03-03T10:34:08.332Z,39.7231,22.211,10,5,mb,,35,0.435,0.53,us,us7000df42,2021-05-13T22:42:01.040Z,"6 km WSW of Týrnavos, Greece",earthquake,5.7,1.8,0.053,114,reviewed,us,us
+2021-03-03T10:16:09.755Z,39.7546,22.1757,8,6.3,mww,,17,0.423,0.55,us,us7000df40,2022-02-26T20:35:47.061Z,"9 km W of Týrnavos, Greece",earthquake,2.7,1.8,0.034,81,reviewed,us,us
+2021-02-17T18:35:35.180Z,30.839,51.3651,7,5.4,mww,,30,7.265,0.86,us,us6000difx,2021-04-23T21:04:52.040Z,"28 km NW of Yasuj, Iran",earthquake,7.1,1.8,0.086,13,reviewed,us,us
+2021-02-17T03:36:07.058Z,38.4057,22.019,5.29,5.5,mww,,38,0.662,0.36,us,us6000diae,2021-04-23T21:04:49.040Z,"11 km N of Kamárai, Greece",earthquake,5.5,3.1,0.047,44,reviewed,us,us
+2021-02-05T15:36:11.039Z,40.5023,45.3486,12.83,5.2,mww,,52,0.584,1.15,us,us6000detl,2021-04-22T21:50:24.040Z,"9 km SSW of Vahan, Armenia",earthquake,4.4,3.6,0.054,33,reviewed,us,us
+2021-02-01T08:35:18.153Z,39.0217,26.0784,10,5.2,mww,,42,0.645,0.54,us,us6000ddle,2021-04-16T19:02:49.040Z,"11 km SW of Polichnítos, Greece",earthquake,1.8,1.8,0.054,33,reviewed,us,us
+2021-01-21T14:27:06.745Z,35.0489,33.7163,62.88,5,mb,,43,0.328,0.98,us,us7000d23a,2022-01-01T02:47:44.060Z,"1 km NE of Pérgamos, Cyprus",earthquake,4.7,3.4,0.049,130,reviewed,us,us
+2021-01-12T22:09:57.263Z,38.4129,22.0649,10,5.2,mww,,29,0.643,0.92,us,us6000d7vr,2021-03-20T21:24:56.040Z,"13 km NNE of Kamárai, Greece",earthquake,5.9,1.8,0.059,28,reviewed,us,us
+2021-01-02T01:05:51.643Z,42.0975,48.0137,10,5.1,mb,,60,3.147,1.1,us,us6000d4we,2022-08-09T02:15:07.008Z,"5 km SW of Gedzhukh, Russia",earthquake,3.4,1.8,0.045,161,reviewed,us,us
+2020-12-29T11:19:54.762Z,45.4244,16.2573,10,6.4,mww,,13,0.941,0.75,us,us6000d3zh,2022-07-23T13:38:28.016Z,"2 km WSW of Petrinja, Croatia",earthquake,4.4,1.8,0.033,89,reviewed,us,us
+2020-12-27T06:37:32.897Z,38.4563,39.2302,9,5.5,mww,,26,0.945,0.55,us,us6000d3dd,2022-03-10T05:51:20.919Z,"7 km WNW of Sivrice, Turkey",earthquake,3.9,1.8,0.043,51,reviewed,us,us
+2020-12-05T12:44:40.454Z,36.0719,31.8808,84.52,5.3,mww,,29,1.621,0.9,us,us7000cnf1,2021-02-12T22:39:25.040Z,"45 km WSW of Gazipa?a, Turkey",earthquake,5.3,4.2,0.045,48,reviewed,us,us
+2020-12-03T05:45:19.821Z,37.9458,41.697,10,5,mww,,39,0.659,0.65,us,us7000cmfa,2021-02-12T22:38:33.040Z,"2 km NNE of Kurtalan, Turkey",earthquake,6.3,1.8,0.098,10,reviewed,us,us
+2020-11-11T03:54:14.890Z,41.6751,20.7949,10,5,mww,,17,1.368,0.76,us,us7000cd8k,2021-11-07T02:53:00.468Z,"11 km SSW of Vrutok, North Macedonia",earthquake,4.9,1.8,0.045,47,reviewed,us,us
+2020-10-30T15:14:55.887Z,37.8319,26.8222,10,5.3,mww,,32,1.518,1.28,us,us7000c7zh,2021-01-18T23:01:48.040Z,"8 km NW of Kokkári, Greece",earthquake,5.2,1.9,0.098,10,reviewed,us,us
+2020-10-30T11:51:27.348Z,37.8973,26.7838,21,7,mww,,18,1.518,0.59,us,us7000c7y0,2022-10-31T19:13:51.035Z,"13 km NNE of Néon Karlovásion, Greece",earthquake,1.4,1.8,0.036,75,reviewed,us,us
+2020-10-26T21:34:51.220Z,32.1448,56.0268,10,5,mb,,57,5.667,1.05,us,us6000cdjs,2022-08-09T01:12:17.934Z,"84 km NE of B?fq, Iran",earthquake,7.5,1.8,0.045,156,reviewed,us,us
+2020-10-24T11:34:17.923Z,35.7462,48.9355,10,5,mww,,34,2.699,0.72,us,us6000cckl,2021-01-09T20:05:23.040Z,"51 km SSW of Abhar, Iran",earthquake,4,1.8,0.098,10,reviewed,us,us
+2020-10-21T23:00:54.450Z,37.3185,20.5134,9.85,5.2,mww,,25,1.135,0.6,us,us6000cb28,2021-01-09T20:05:17.040Z,"52 km SSW of Lithakiá, Greece",earthquake,6.2,3.5,0.053,34,reviewed,us,us
+2020-10-12T04:11:27.566Z,35.6445,26.2467,10,5.2,mww,,30,0.751,1.06,us,us6000c7nd,2020-12-19T17:22:46.040Z,"49 km N of Palekastro, Greece",earthquake,3.3,1.7,0.05,38,reviewed,us,us
+2020-10-12T00:30:39.934Z,35.5856,26.2443,10,5.1,mww,,44,0.748,0.83,us,us6000c7m8,2020-12-19T17:22:46.040Z,"43 km N of Palekastro, Greece",earthquake,4.8,1.8,0.05,38,reviewed,us,us
+2020-10-01T11:05:38.322Z,36.7385,26.7488,154.43,5,mb,,36,1.223,0.84,us,us6000c3tv,2020-12-12T22:28:29.040Z,"Dodecanese Islands, Greece",earthquake,6.2,5.2,0.039,209,reviewed,us,us
+2020-09-26T22:50:25.082Z,39.9847,24.3349,10.38,5.4,mww,,16,1.585,0.58,us,us6000c1rq,2020-12-05T21:03:00.040Z,"31 km SSE of Karyes, Greece",earthquake,5.8,3.8,0.046,45,reviewed,us,us
+2020-09-26T05:46:55.523Z,38.1981,56.051,10,5.2,mww,,54,6.282,0.85,us,us6000c1ix,2020-12-05T21:02:59.040Z,"88 km SSW of Serdar, Turkmenistan",earthquake,7.8,1.9,0.069,20,reviewed,us,us
+2020-09-20T19:08:07.568Z,38.0178,34.0419,10,5.1,mww,,51,1.644,1.08,us,us7000bqjg,2020-11-28T21:31:58.040Z,"22 km NE of Emirgazi, Turkey",earthquake,4.9,1.9,0.065,23,reviewed,us,us
+2020-09-18T16:28:17.575Z,35.0368,25.3034,44,5.9,mww,,35,0.421,0.78,us,us7000bpvt,2020-11-28T21:31:51.040Z,"12 km SSE of Arkalochóri, Greece",earthquake,5.9,1.9,0.05,39,reviewed,us,us
+2020-09-06T21:34:26.684Z,36.9796,55.1103,10,5.3,mww,,59,6.355,0.77,us,us7000bj2i,2022-03-10T05:38:46.410Z,"13 km SSW of ?z?dshahr, Iran",earthquake,7.7,1.8,0.089,12,reviewed,us,us
+2020-08-17T07:27:02.373Z,36.8978,23.77,95.34,5,mww,,37,1.502,0.61,us,us6000bfuq,2020-10-24T20:08:58.040Z,"56 km SSE of Ýdra, Greece",earthquake,5.4,1.5,0.056,31,reviewed,us,us
+2020-08-09T09:16:19.840Z,34.2257,45.5918,10,5,mb,,42,0.895,0.66,us,us6000bbdp,2020-10-21T22:04:01.040Z,"36 km SW of Sarpol-e Z?ah?b, Iran",earthquake,4.2,1.9,0.051,121,reviewed,us,us
+2020-08-04T09:37:37.015Z,38.1878,38.698,10,5.6,mww,,30,0.947,0.91,us,us6000b930,2022-03-10T05:30:54.343Z,"18 km NNE of Sincik, Turkey",earthquake,3.1,1.7,0.053,34,reviewed,us,us
+2020-06-28T17:43:28.644Z,36.7481,28.2482,63,5.4,mww,,61,0.543,0.82,us,us7000adtk,2020-09-05T17:35:30.040Z,"5 km SSE of ?çmeler, Turkey",earthquake,4.9,1.9,0.058,29,reviewed,us,us
+2020-06-26T07:21:12.533Z,38.7898,27.7934,10,5.2,mww,,42,0.668,0.73,us,us7000abxv,2020-09-05T17:35:22.040Z,"13 km NW of Gölmarmara, Turkey",earthquake,2.7,1.9,0.06,27,reviewed,us,us
+2020-06-25T10:03:30.648Z,38.5329,43.9407,10,5.4,mww,,28,0.727,1.26,us,us7000aavx,2022-03-10T05:26:05.460Z,"14 km SSW of Özalp, Turkey",earthquake,5.1,1.8,0.071,19,reviewed,us,us
+2020-06-19T07:43:21.049Z,34.2871,25.5222,10,5.1,mww,,45,1.126,0.62,us,us6000aepr,2020-08-30T00:00:49.040Z,"81 km S of Néa Anatolí, Greece",earthquake,7.1,1.9,0.08,15,reviewed,us,us
+2020-06-15T06:51:31.776Z,39.4226,40.7479,10,5.5,mww,,37,0.625,0.57,us,us6000ac28,2022-03-10T05:23:39.598Z,"18 km E of Yedisu, Turkey",earthquake,4.4,1.8,0.053,34,reviewed,us,us
+2020-06-14T14:24:29.501Z,39.4229,40.7073,10,5.9,mww,,24,0.615,0.62,us,us6000abnv,2022-03-10T05:22:54.331Z,"14 km E of Yedisu, Turkey",earthquake,4.7,1.8,0.039,64,reviewed,us,us
+2020-06-05T18:06:21.607Z,38.2379,38.7587,10,5.1,mww,,29,0.915,0.78,us,us6000a6qw,2022-03-10T05:20:42.962Z,"25 km WSW of Do?anyol, Turkey",earthquake,4.3,1.8,0.066,22,reviewed,us,us
+2020-06-03T09:03:29.381Z,34.3323,25.8927,10,5.4,mww,,63,1.26,0.62,us,us6000a52k,2020-08-18T17:58:45.040Z,"76 km S of Ierápetra, Greece",earthquake,7.2,1.8,0.098,10,reviewed,us,us
+2020-06-03T08:16:53.519Z,33.4162,46.1104,10,5,mb,,49,1.727,1.11,us,us6000a50y,2020-08-18T17:58:45.040Z,"32 km N of Mehr?n, Iran",earthquake,6.8,1.8,0.039,215,reviewed,us,us
+2020-05-27T01:09:52.824Z,34.2263,25.6224,10,5.1,mww,,27,1.218,0.63,us,us60009zq8,2020-08-15T20:19:35.040Z,"86 km S of Néa Anatolí, Greece",earthquake,3,1.7,0.05,38,reviewed,us,us
+2020-05-23T22:50:12.589Z,34.2955,25.5138,14.41,5.3,mww,,17,1.115,0.71,us,us70009p8k,2020-08-08T18:17:54.040Z,"80 km S of Néa Anatolí, Greece",earthquake,6.2,3.3,0.068,21,reviewed,us,us
+2020-05-22T03:40:30.610Z,34.4832,25.8869,10,5.1,mww,,61,1.147,0.97,us,us70009n06,2020-08-08T18:17:48.040Z,"60 km SSE of Ierápetra, Greece",earthquake,6,1.8,0.056,31,reviewed,us,us
+2020-05-20T23:43:16.920Z,35.1594,20.2775,13.45,5.7,mww,,22,2.416,0.52,us,us70009m4x,2020-08-08T18:17:45.040Z,"224 km SW of Methóni, Greece",earthquake,6.7,3.4,0.048,42,reviewed,us,us
+2020-05-18T23:22:35.162Z,34.1855,25.5173,10,5.7,mww,,17,1.215,0.6,us,us70009k7k,2020-08-02T00:28:34.040Z,"92 km S of Néa Anatolí, Greece",earthquake,5.5,1.7,0.073,18,reviewed,us,us
+2020-05-18T11:48:07.371Z,34.1328,25.5231,10,5,mww,,28,1.265,0.71,us,us70009jm3,2020-08-02T00:28:51.040Z,"98 km S of Néa Anatolí, Greece",earthquake,7.1,1.8,0.075,17,reviewed,us,us
+2020-05-18T04:18:17.970Z,34.1648,25.6205,10,5.2,mww,,45,1.271,0.86,us,us70009jdm,2020-08-02T00:29:03.040Z,"93 km S of Néa Anatolí, Greece",earthquake,6.9,1.8,0.05,39,reviewed,us,us
+2020-05-02T16:44:26.565Z,34.118,25.6064,10,5.3,mww,,47,1.307,1,us,us700098uz,2020-07-18T21:57:13.040Z,"98 km S of Néa Anatolí, Greece",earthquake,6.6,1.8,0.051,37,reviewed,us,us
+2020-05-02T13:33:49.621Z,34.1503,25.4585,10,5.3,mww,,61,1.227,0.95,us,us700098rs,2020-07-18T21:57:12.040Z,"97 km S of Néa Anatolí, Greece",earthquake,3.4,1.8,0.078,16,reviewed,us,us
+2020-05-02T12:51:05.561Z,34.1818,25.7101,10,6.5,mww,,19,1.293,1.01,us,us700098qd,2022-03-10T05:14:18.344Z,"91 km S of Néa Anatolí, Greece",earthquake,6.7,1.8,0.048,42,reviewed,us,us
+2020-03-22T05:24:03.700Z,45.9072,15.9697,10,5.3,mww,,12,0.794,0.59,us,us70008dx7,2023-02-17T14:06:55.780Z,"5 km E of Gornja Bistra, Croatia",earthquake,3.7,1.8,0.035,79,reviewed,us,us
+2020-03-21T00:49:51.370Z,39.3567,20.6383,10,5.7,mww,,14,0.742,0.71,us,us70008db1,2022-03-10T05:09:29.482Z,"14 km NNE of Kanaláki, Greece",earthquake,4.7,1.7,0.037,70,reviewed,us,us
+2020-03-19T17:53:33.384Z,38.3915,39.0729,10,5.2,mww,,52,0.907,1.22,us,us70008cbe,2020-06-06T20:53:54.040Z,"9 km NNE of Do?anyol, Turkey",earthquake,3.3,1.5,0.061,26,reviewed,us,us
+2020-02-25T23:03:37.816Z,38.3489,38.7972,10,5,mww,,59,0.826,0.82,us,us600084bs,2020-05-09T21:40:46.040Z,"21 km WNW of Do?anyol, Turkey",earthquake,4.3,1.8,0.093,11,reviewed,us,us
+2020-02-23T16:00:31.626Z,38.4958,44.3732,10,6,mww,,18,1.049,0.92,us,us70007v9g,2022-03-10T05:06:48.661Z,"37 km ESE of Özalp, Turkey",earthquake,3.5,1.8,0.05,38,reviewed,us,us
+2020-02-23T05:53:01.055Z,38.4465,44.4168,10,5.8,mww,,22,1.075,0.78,us,us70007v29,2022-03-10T05:06:34.354Z,"41 km NW of Salm?s, Iran",earthquake,4.7,1.8,0.055,32,reviewed,us,us
+2020-01-30T11:21:36.743Z,35.1817,27.7814,10,5.7,mww,,36,0.624,1.16,us,us60007jzj,2020-04-18T22:09:56.040Z,"63 km SE of Karpathos, Greece",earthquake,5.2,1.8,0.052,36,reviewed,us,us
+2020-01-30T01:28:05.202Z,35.1565,27.8845,10,5.5,mww,,33,0.708,0.9,us,us60007jpa,2020-04-18T22:09:55.040Z,"72 km ESE of Karpathos, Greece",earthquake,5.3,1.8,0.055,32,reviewed,us,us
+2020-01-28T20:15:08.171Z,41.4656,19.5362,10,5.1,mb,,19,0.985,1.13,us,us60007ifh,2020-04-11T18:21:03.040Z,"12 km NW of Vorë, Albania",earthquake,4.6,1.8,0.035,270,reviewed,us,us
+2020-01-28T15:38:34.436Z,35.2183,27.8918,10,5.5,mww,,37,0.681,0.65,us,us60007i7j,2022-08-08T18:09:33.534Z,"69 km ESE of Karpathos, Greece",earthquake,5.2,1.7,0.052,35,reviewed,us,us
+2020-01-28T11:26:15.000Z,39.1061,27.875,10,5,mww,,20,0.533,0.8,us,us60007i49,2020-04-11T18:21:01.040Z,Western Turkey,earthquake,4.5,1.8,0.065,23,reviewed,us,us
+2020-01-25T16:30:11.109Z,38.3615,39.1096,10,5.1,mww,,59,0.948,0.82,us,us60007fs4,2020-04-11T18:20:49.040Z,"8 km NE of Do?anyol, Turkey",earthquake,3.2,1.6,0.068,21,reviewed,us,us
+2020-01-24T17:55:14.147Z,38.4312,39.0609,10,6.7,mww,,49,0.87,0.69,us,us60007ewc,2022-03-10T05:02:23.447Z,"13 km N of Do?anyol, Turkey",earthquake,5,1.8,0.043,51,reviewed,us,us
+2020-01-22T19:22:16.298Z,39.0724,27.8389,5.6,5.6,mww,,18,0.567,0.66,us,us60007d2r,2022-03-10T05:01:41.040Z,"15 km ESE of K?rka?aç, Turkey",earthquake,4.1,3.1,0.057,30,reviewed,us,us
+2020-01-19T02:52:09.244Z,38.2582,20.7505,10,5.1,mww,,47,1.424,1,us,us60007aen,2020-04-08T19:39:38.040Z,"9 km E of Sámi, Greece",earthquake,4.9,1.8,0.048,41,reviewed,us,us
+2020-01-02T04:29:06.582Z,34.1326,60.2681,10,5.5,mww,,45,1.655,0.91,us,us70006tev,2022-03-04T17:36:59.119Z,"81 km SW of T?yb?d, Iran",earthquake,6.6,1.7,0.089,12,reviewed,us,us
+2019-12-10T21:58:28.855Z,35.4972,26.4467,57.87,5.4,mww,,22,0.584,0.82,us,us60006pxs,2020-03-04T21:26:51.040Z,"37 km NNE of Palekastro, Greece",earthquake,5.9,4.4,0.068,21,reviewed,us,us
+2019-11-29T17:20:13.576Z,31.9436,49.8143,10,5,mb,,60,2.23,0.79,us,us70006ehm,2020-02-19T18:58:20.040Z,"48 km E of Masjed Soleym?n, Iran",earthquake,1.7,1.8,0.04,205,reviewed,us,us
+2019-11-28T10:52:41.876Z,41.5368,19.422,10,5,mb,,37,0.9,0.81,us,us70006e5g,2020-02-19T18:58:17.040Z,"22 km WSW of Mamurras, Albania",earthquake,5.2,1.8,0.04,199,reviewed,us,us
+2019-11-27T14:45:23.989Z,41.5498,19.4787,10,5.3,mww,,39,0.894,0.92,us,us70006dsc,2020-02-19T18:58:12.040Z,"18 km W of Mamurras, Albania",earthquake,4.5,1.8,0.058,29,reviewed,us,us
+2019-11-27T07:23:42.383Z,35.7174,23.2284,69,6,mww,,18,1.421,1.02,us,us70006dlt,2020-02-19T18:58:10.040Z,"45 km WNW of Kíssamos, Greece",earthquake,6.5,1.9,0.051,37,reviewed,us,us
+2019-11-26T09:19:25.856Z,43.2235,17.9118,10,5.3,mww,,24,1.27,0.86,us,us70006d4h,2020-12-29T14:18:53.242Z,"4 km SSE of Blagaj, Bosnia and Herzegovina",earthquake,5.5,1.8,0.058,29,reviewed,us,us
+2019-11-26T06:08:21.820Z,41.5708,19.4242,10,5.5,mww,,19,0.866,1.34,us,us70006d2z,2020-07-10T17:54:46.671Z,"22 km W of Mamurras, Albania",earthquake,5.7,1.8,0.038,65,reviewed,us,us
+2019-11-26T03:02:59.558Z,41.422,19.6383,10,5.3,mb,,48,1.045,0.87,us,us70006d0w,2020-02-19T18:58:04.040Z,"3 km NNW of Vorë, Albania",earthquake,5.3,1.9,0.136,18,reviewed,us,us
+2019-11-26T02:59:23.982Z,41.4216,19.5323,10,5.1,mb,,29,1.027,0.85,us,us70006d1f,2020-02-19T18:58:04.040Z,"8 km NNW of Shijak, Albania",earthquake,4.7,1.9,0.147,15,reviewed,us,us
+2019-11-26T02:54:12.872Z,41.5138,19.5256,22,6.4,mww,,17,0.936,0.61,us,us70006d0m,2021-01-16T12:28:56.303Z,"15 km WSW of Mamurras, Albania",earthquake,4.3,1.8,0.037,72,reviewed,us,us
+2019-11-07T22:47:07.041Z,37.8026,47.5814,20,5.9,mww,,20,2.752,0.67,us,us600068w0,2020-10-24T11:56:21.590Z,"59 km NE of Hashtr?d, Iran",earthquake,6.5,1.7,0.059,28,reviewed,us,us
+2019-10-05T14:51:37.881Z,35.9894,27.978,76.05,5,mb,,131,0.252,0.93,us,us70005r33,2019-12-27T15:50:37.040Z,"12 km SSW of Lárdos, Greece",earthquake,6.7,5,0.075,56,reviewed,us,us
+2019-10-03T04:44:56.550Z,36.2765,28.5721,17.77,5.1,mww,,41,0.369,1,us,us70005q4l,2019-12-27T15:50:04.040Z,"34 km ESE of Faliraki, Greece",earthquake,4,3.6,0.071,19,reviewed,us,us
+2019-09-26T10:59:25.648Z,40.9035,28.1502,8,5.7,mww,,19,1.595,0.9,us,us70005lkl,2023-02-16T23:32:27.836Z,"17 km ESE of Marmara Ere?lisi, Turkey",earthquake,5.2,1.8,0.033,88,reviewed,us,us
+2019-09-21T14:15:52.981Z,41.4685,19.5438,13.73,5.1,mwr,,40,0.983,1.06,us,us60005lrg,2019-12-10T17:27:01.040Z,"12 km NW of Vorë, Albania",earthquake,5.1,2.6,0.057,30,reviewed,us,us
+2019-09-21T14:04:25.803Z,41.3375,19.5303,20,5.6,mww,,34,1.109,1.13,us,us60005lrf,2021-01-16T12:21:33.387Z,"3 km WSW of Shijak, Albania",earthquake,2.1,1.8,0.042,55,reviewed,us,us
+2019-08-11T07:02:49.770Z,34.3087,25.0038,10,5,mb,,63,0.981,0.87,us,us600053n2,2019-10-29T20:33:58.040Z,"78 km S of Pýrgos, Greece",earthquake,7.6,1.9,0.033,287,reviewed,us,us
+2019-08-08T11:25:31.104Z,37.935,29.7003,11,5.9,mww,,25,0.646,0.96,us,us6000529r,2020-07-10T17:33:55.739Z,"9 km ESE of Baklan, Turkey",earthquake,4.7,1.7,0.039,64,reviewed,us,us
+2019-08-04T19:51:16.008Z,30.5857,50.8453,7.72,5.4,mb,,42,6.245,0.89,us,us600050lk,2020-07-10T17:33:32.117Z,"25 km N of Dogonbadan, Iran",earthquake,7.4,1.8,0.036,267,reviewed,us,us
+2019-08-03T09:51:24.191Z,35.2241,27.845,10,5.1,mww,,49,0.645,0.84,us,us6000504d,2019-10-19T21:42:07.040Z,"65 km ESE of Karpathos, Greece",earthquake,6,1.8,0.051,37,reviewed,us,us
+2019-07-19T11:13:15.693Z,38.0951,23.5251,10,5.3,mww,,35,1.565,0.67,us,us70004nt3,2021-02-18T17:52:49.606Z,"1 km NNE of Magoúla, Greece",earthquake,4.5,1.8,0.05,39,reviewed,us,us
+2019-07-08T07:00:32.441Z,31.7564,49.5611,19,5.6,mww,,36,2.03,0.69,us,us70004ejm,2020-07-10T17:43:51.391Z,"31 km SE of Masjed Soleym?n, Iran",earthquake,6.7,1.8,0.098,10,reviewed,us,us
+2019-06-01T07:00:28.533Z,40.5713,20.7398,10,5,mww,,36,1.02,0.81,us,us70003u24,2022-08-08T13:57:39.332Z,"6 km SSW of Korçë, Albania",earthquake,5.1,1.8,0.039,63,reviewed,us,us
+2019-06-01T04:26:19.636Z,40.5257,20.7025,10,5.2,mww,,33,1.038,1.22,us,us70003u1a,2020-07-10T17:41:55.855Z,"12 km SW of Mborje, Albania",earthquake,4.6,1.8,0.033,89,reviewed,us,us
+2019-05-11T10:28:59.929Z,34.9557,45.7333,10,5.2,mww,,50,0.161,0.7,us,us70003jrw,2019-08-01T17:15:10.040Z,"33 km SW of ?alabja, Iraq",earthquake,8.4,1.9,0.066,22,reviewed,us,us
+2019-04-04T17:31:10.169Z,38.3002,39.1625,10,5.2,mww,,31,1.614,0.99,us,us2000kacn,2019-06-18T15:50:20.040Z,"11 km E of Do?anyol, Turkey",earthquake,5.3,1.9,0.046,46,reviewed,us,us
+2019-04-01T10:07:23.671Z,33.5495,45.7739,10,5.3,mww,,48,1.564,1.05,us,us2000k8fr,2019-06-08T20:51:30.040Z,"29 km SE of Mandal?, Iraq",earthquake,6.8,1.8,0.062,25,reviewed,us,us
+2019-03-31T11:30:17.785Z,37.5063,29.3787,10,5.1,mww,,35,0.867,0.79,us,us2000k7yn,2019-06-08T20:51:27.040Z,"9 km NNE of Ac?payam, Turkey",earthquake,5,1.8,0.038,68,reviewed,us,us
+2019-03-30T10:46:19.174Z,38.3657,22.3935,10,5.3,mww,,20,1.241,0.75,us,us2000k7ki,2021-02-10T17:50:44.927Z,"2 km SE of Galaxídhion, Greece",earthquake,5.7,1.8,0.044,50,reviewed,us,us
+2019-03-20T06:34:27.835Z,37.4078,29.531,8,5.7,mww,,31,0.724,1.15,us,us1000jj23,2020-07-10T16:04:08.738Z,"16 km E of Ac?payam, Turkey",earthquake,5,1.8,0.035,77,reviewed,us,us
+2019-02-20T18:23:29.480Z,39.6916,26.4007,10,5.1,mww,,37,1.222,0.75,us,us2000jkr3,2020-07-10T17:25:55.201Z,"10 km N of Ayvac?k, Turkey",earthquake,5.3,1.7,0.055,32,reviewed,us,us
+2019-02-05T19:31:36.261Z,40.8961,48.6067,10,5,mww,,39,3.039,0.97,us,us2000jds8,2020-07-10T17:25:00.340Z,"23 km NE of Basqal, Azerbaijan",earthquake,6.9,1.8,0.086,13,reviewed,us,us
+2019-02-05T02:26:09.760Z,39.052,20.5868,7.73,5.4,mww,,23,0.9,0.68,us,us2000jdgj,2019-04-25T15:31:39.040Z,"16 km SW of Néos Oropós, Greece",earthquake,5,3.2,0.04,60,reviewed,us,us
+2019-01-24T14:30:54.040Z,36.0652,28.0928,47.7,5.1,mww,,41,0.149,0.89,us,us2000j898,2022-08-08T11:46:44.301Z,"7 km ESE of Lárdos, Greece",earthquake,6.8,4.1,0.058,29,reviewed,us,us
+2019-01-10T18:24:41.280Z,34.5801,26.6262,36.37,5,mb,,43,1.059,1.2,us,us2000j2mg,2019-04-02T20:51:02.040Z,"76 km SSE of Palekastro, Greece",earthquake,6.4,6.5,0.05,129,reviewed,us,us
+2019-01-06T13:41:59.060Z,34.1248,45.6794,14,5.6,mww,,40,0.99,0.65,us,us2000j0th,2022-08-08T11:16:50.865Z,"40 km SSW of Sarpol-e Z?ah?b, Iran",earthquake,5.6,1.8,0.059,28,reviewed,us,us
+2018-12-26T02:19:14.000Z,37.63,15.1,1,5,mwr,,,,1.07,us,us2000ixky,2022-05-03T19:42:42.222Z,"1 km SSW of Lavinaio-Monterosso, Italy",earthquake,5.1,3.2,0.08,15,reviewed,rom,us
+2018-11-25T23:00:46.470Z,34.238,45.6438,10,5,mb,,87,0.879,0.54,us,us1000hwi6,2022-05-03T19:39:55.862Z,"31 km SW of Sarpol-e Z?ah?b, Iran",earthquake,5.8,1.8,0.037,228,reviewed,us,us
+2018-11-25T17:09:36.010Z,34.4157,45.7209,10,5.2,mww,,67,0.699,0.93,us,us1000hwe7,2022-05-03T19:39:55.011Z,"13 km WSW of Sarpol-e Z?ah?b, Iran",earthquake,7.4,1.8,0.071,19,reviewed,us,us
+2018-11-25T16:37:32.830Z,34.3609,45.7443,18,6.3,mww,,22,0.754,0.86,us,us1000hwdw,2022-05-03T19:39:53.541Z,"15 km SW of Sarpol-e Z?ah?b, Iran",earthquake,5.7,1.8,0.059,28,reviewed,us,us
+2018-11-19T13:05:56.210Z,37.282,20.6169,10.58,5.2,mww,,40,1.049,1.08,us,us1000htwc,2022-05-03T19:39:13.547Z,"52 km SSW of Lithakiá, Greece",earthquake,5.6,3.7,0.056,31,reviewed,us,us
+2018-11-06T01:17:19.800Z,42.533,43.5963,10,5,mb,,30,1.567,0.59,us,us2000i79c,2022-08-08T09:56:41.661Z,"13 km ESE of Oni, Georgia",earthquake,5.3,1.3,0.037,237,reviewed,us,us
+2018-10-30T15:12:00.610Z,37.5124,20.5076,11,5.7,mww,,36,2.083,0.75,us,us1000hj1l,2022-05-03T19:57:39.090Z,"36 km SW of Lithakiá, Greece",earthquake,5.4,1.8,0.06,27,reviewed,us,us
+2018-10-30T08:32:26.240Z,37.477,20.4661,15.75,5.1,mww,,55,2.131,0.88,us,us1000hiy9,2019-01-21T14:29:39.040Z,"41 km SW of Lithakiá, Greece",earthquake,6.3,4.6,0.073,18,reviewed,us,us
+2018-10-30T02:59:58.200Z,37.5857,20.4876,10,5.1,mww,,36,2.191,0.72,us,us1000hivt,2019-01-21T14:29:39.040Z,"33 km WSW of Lithakiá, Greece",earthquake,5.9,1.8,0.11,8,reviewed,us,us
+2018-10-28T00:38:11.610Z,45.6575,26.3972,151,5.5,mww,,10,0.231,0.88,us,us1000hi43,2022-05-03T19:54:06.044Z,"15 km SE of Comand?u, Romania",earthquake,5.1,1.8,0.046,45,reviewed,us,us
+2018-10-26T12:41:12.950Z,37.5468,20.5651,10,5.1,mww,,39,2.244,0.96,us,us1000hhj7,2022-05-03T19:36:58.380Z,"30 km SW of Lithakiá, Greece",earthquake,5.5,1.9,0.061,26,reviewed,us,us
+2018-10-26T05:48:37.100Z,37.489,20.6009,10,5.1,mww,,36,2.308,0.84,us,us1000hhf8,2022-05-03T19:36:45.189Z,"32 km SW of Lithakiá, Greece",earthquake,6.1,1.8,0.089,12,reviewed,us,us
+2018-10-26T01:06:04.540Z,37.4059,20.8466,10,5,mb,,36,2.446,1.31,us,us1000hhcr,2019-01-10T17:18:37.040Z,"34 km S of Lithakiá, Greece",earthquake,6.3,1.8,0.043,174,reviewed,us,us
+2018-10-26T00:32:54.260Z,37.7243,20.3475,10,5,mb,,52,2.031,0.85,us,us1000hhcb,2019-01-10T17:18:37.040Z,"37 km WSW of Katastárion, Greece",earthquake,6.2,1.8,0.054,108,reviewed,us,us
+2018-10-25T23:09:21.420Z,37.2426,20.6146,10,5.1,mb,,81,2.548,1.12,us,us1000hhba,2019-01-10T17:18:37.040Z,"56 km SSW of Lithakiá, Greece",earthquake,5.3,1.9,0.068,71,reviewed,us,us
+2018-10-25T22:54:52.630Z,37.5203,20.5565,14,6.8,mww,,15,2.268,0.82,us,us1000hhb1,2022-05-03T19:36:42.091Z,"32 km SW of Lithakiá, Greece",earthquake,4.9,1.7,0.043,51,reviewed,us,us
+2018-10-25T22:22:54.760Z,37.4501,20.5853,10,5.1,mb,,28,2.342,0.92,us,us1000hhay,2019-01-10T17:18:37.040Z,"36 km SW of Lithakiá, Greece",earthquake,5.7,1.8,0.036,251,reviewed,us,us
+2018-09-27T10:21:49.480Z,36.8055,21.4351,10,5.4,mww,,49,3.176,1.12,us,us1000h36s,2022-05-03T19:31:49.751Z,"24 km W of Methóni, Greece",earthquake,5.8,1.9,0.054,33,reviewed,us,us
+2018-09-12T06:21:48.440Z,36.185,31.0563,50.02,5.3,mww,,51,1.082,1.37,us,us2000hdam,2021-01-22T13:10:21.699Z,"59 km SE of Tekirova, Turkey",earthquake,6,4.8,0.053,34,reviewed,us,us
+2018-09-10T23:02:56.060Z,37.2304,30.6131,108.14,5.1,mwr,,25,0.617,0.62,us,us2000hc6y,2018-11-21T18:19:08.040Z,"14 km SW of Kocaaliler, Turkey",earthquake,5.2,3.7,0.066,22,reviewed,us,us
+2018-08-31T21:05:44.360Z,34.6512,46.0736,10,5.3,mwr,,40,0.548,0.71,us,us2000h691,2018-11-07T18:37:07.040Z,"28 km NE of Sarpol-e Z?ah?b, Iran",earthquake,5.2,1.8,0.086,13,reviewed,us,us
+2018-08-31T07:12:25.340Z,39.3299,21.683,10.44,5.1,mww,,56,1.464,0.93,us,us2000h5w7,2022-05-03T19:28:39.872Z,"6 km WSW of Morfovoúni, Greece",earthquake,5,3.2,0.052,35,reviewed,us,us
+2018-08-28T12:57:13.940Z,38.8209,48.8124,10,5,mb,,38,3.417,0.68,us,us1000gikw,2022-08-08T07:32:36.549Z,"7 km NE of Haftoni, Azerbaijan",earthquake,5,1.8,0.037,234,reviewed,us,us
+2018-08-25T22:13:25.620Z,34.6111,46.2422,10,6,mww,,28,0.662,0.79,us,us1000ghda,2022-05-03T19:28:29.129Z,"32 km SW of Jav?nr?d, Iran",earthquake,6,1.8,0.065,23,reviewed,us,us
+2018-08-19T15:22:14.240Z,37.2897,36.364,10,5.1,mb,,48,0.685,0.67,us,us1000gdb1,2018-10-27T16:22:07.040Z,"21 km WNW of Bahçe, Turkey",earthquake,4.7,1.9,0.119,29,reviewed,us,us
+2018-08-16T18:19:05.400Z,41.8753,14.8084,11.59,5.3,mww,,25,0.687,1.14,us,us1000gaq7,2022-05-03T19:27:17.024Z,"2 km SE of Palata, Italy",earthquake,4.9,3.7,0.048,41,reviewed,us,us
+2018-08-11T15:38:33.550Z,41.5869,20.1018,10,5.1,mww,,26,0.299,0.94,us,us1000g6wx,2022-05-03T19:26:56.297Z,"8 km ESE of Burrel, Albania",earthquake,4.3,1.3,0.062,25,reviewed,us,us
+2018-07-22T20:39:17.390Z,30.4313,57.4531,10,5.6,mww,,61,16.388,0.89,us,us2000gbea,2022-05-03T19:24:24.974Z,"39 km ENE of Kerman, Iran",earthquake,10.1,1.9,0.062,25,reviewed,us,us
+2018-07-22T10:07:27.220Z,34.5909,46.1661,12,5.8,mww,,30,0.64,1.04,us,us2000gb4d,2022-05-03T19:24:07.226Z,"31 km ENE of Sarpol-e Z?ah?b, Iran",earthquake,5.9,1.8,0.065,23,reviewed,us,us
+2018-07-04T09:01:09.570Z,41.4466,19.5828,22,5.1,mww,,20,0.233,0.71,us,us2000fwnu,2022-05-03T19:20:49.705Z,"8 km NW of Vorë, Albania",earthquake,1.1,1.9,0.069,20,reviewed,us,us
+2018-06-25T05:14:44.990Z,36.6404,21.3431,10,5.5,mww,,30,0.711,0.97,us,us1000f0te,2022-05-03T19:20:08.631Z,"37 km WSW of Methóni, Greece",earthquake,4.5,1.7,0.04,60,reviewed,us,us
+2018-06-05T18:40:30.020Z,41.5263,46.7857,22.65,5.3,mww,,30,2.074,0.82,us,us1000ej4g,2022-08-08T04:27:28.558Z,"2 km SE of Mamrux, Azerbaijan",earthquake,6.2,4,0.078,16,reviewed,us,us
+2018-05-16T22:30:03.120Z,36.5121,22.9324,10.44,5,mb,,33,1.046,0.82,us,us1000e6uj,2022-05-03T19:56:39.897Z,"21 km SSW of Géfyra, Greece",earthquake,5.7,3.9,0.046,154,reviewed,us,us
+2018-05-06T19:57:01.780Z,30.6925,51.483,10,5.3,mb,,42,7.047,0.89,us,us1000dzhm,2022-05-03T19:11:51.885Z,"10 km WNW of Yasuj, Iran",earthquake,7,1.8,0.044,176,reviewed,us,us
+2018-05-02T04:08:13.400Z,30.7048,51.4904,8,5.3,mww,,23,6.548,0.82,us,us1000dvqr,2022-05-03T19:11:05.989Z,"10 km WNW of Yasuj, Iran",earthquake,6.8,1.8,0.061,26,reviewed,us,us
+2018-04-24T00:34:31.180Z,37.5963,38.5142,10,5.2,mww,,30,1.122,0.92,us,us1000dr1j,2022-08-08T02:28:45.817Z,"3 km ENE of Samsat, Turkey",earthquake,5.4,1.7,0.089,12,reviewed,us,us
+2018-04-01T08:35:26.410Z,34.4028,45.7476,10,5,mww,,45,0.712,0.88,us,us1000dc2w,2022-05-03T19:08:57.724Z,"12 km WSW of Sarpol-e Z?ah?b, Iran",earthquake,4.1,1.9,0.089,12,reviewed,us,us
+2018-03-19T19:32:22.850Z,30.685,50.3867,10,5.1,mb,,47,5.909,0.92,us,us1000d6k4,2022-05-03T18:49:54.978Z,"17 km NE of Behbah?n, Iran",earthquake,5.7,1.4,0.039,214,reviewed,us,us
+2018-02-21T23:44:56.360Z,37.8538,20.3633,20.08,5,mb,,39,1.908,0.94,us,us2000d66w,2018-05-22T02:00:21.040Z,"34 km W of Katastárion, Greece",earthquake,5.7,5,0.049,133,reviewed,us,us
+2018-01-19T22:17:55.880Z,33.7156,45.7137,10,5,mb,,84,1.397,0.83,us,us2000clji,2022-08-07T23:14:29.464Z,"15 km ESE of Mandal?, Iraq",earthquake,6.1,1.8,0.036,245,reviewed,us,us
+2018-01-11T08:00:39.860Z,33.7205,45.7027,10,5.3,mww,,75,1.393,0.59,us,us2000ci4h,2022-05-03T19:02:24.906Z,"14 km ESE of Mandal?, Iraq",earthquake,7.3,1.9,0.061,26,reviewed,us,us
+2018-01-11T07:55:00.430Z,33.711,45.7897,10,5.1,mb,,81,1.403,0.72,us,us2000ci4f,2022-05-03T18:44:47.021Z,"22 km E of Mandal?, Iraq",earthquake,7.7,1.9,0.061,88,reviewed,us,us
+2018-01-11T07:21:43.600Z,33.2164,46.42,10,5.2,mww,,59,1.982,1.01,us,us2000ci3z,2022-05-03T18:45:04.224Z,"26 km ENE of Mehr?n, Iran",earthquake,8.8,1.9,0.078,16,reviewed,us,us
+2018-01-11T07:14:15.990Z,33.8017,45.7299,10,5.3,mww,,68,1.312,0.8,us,us2000ci3y,2022-05-03T18:44:41.888Z,"17 km ENE of Mandal?, Iraq",earthquake,7.3,1.8,0.078,16,reviewed,us,us
+2018-01-11T07:00:52.390Z,33.8578,45.7935,10,5.3,mb,,85,1.257,0.8,us,us2000ci3x,2018-04-03T01:40:25.040Z,"25 km ENE of Mandal?, Iraq",earthquake,9.1,1.9,0.06,92,reviewed,us,us
+2018-01-11T06:59:30.470Z,33.7131,45.7239,10,5.5,mww,,63,1.4,0.61,us,us2000ci3s,2022-08-07T22:57:55.763Z,"16 km ESE of Mandal?, Iraq",earthquake,6.3,1.8,0.054,33,reviewed,us,us
+2018-01-11T03:18:30.200Z,30.7268,57.3359,10,5,mb,,37,5.521,0.69,us,us2000ci2b,2018-04-03T01:40:25.040Z,"55 km NNE of Kerman, Iran",earthquake,3.3,1.8,0.043,178,reviewed,us,us
+2018-01-06T15:22:09.120Z,34.5849,45.7696,10,5,mww,,46,0.532,1.3,us,us1000c1fi,2022-05-03T19:02:12.616Z,"16 km NNW of Sarpol-e Z?ah?b, Iran",earthquake,6.1,1.8,0.068,21,reviewed,us,us
+2018-01-04T10:46:11.670Z,42.6601,19.8624,10,5.1,mww,,18,1.312,0.98,us,us1000c0lz,2022-05-03T19:02:07.464Z,"9 km NW of Plav, Montenegro",earthquake,4.3,1.8,0.051,37,reviewed,us,us
+2017-12-27T18:01:15.090Z,30.8057,57.2499,10,5,mb,,61,5.523,1.04,us,us1000bws4,2022-08-07T22:34:18.831Z,"60 km NNE of Kerman, Iran",earthquake,7.4,1.9,0.041,187,reviewed,us,us
+2017-12-21T17:04:46.580Z,31.3839,56.2594,10,5.2,mww,,43,5.856,1.12,us,us1000buiv,2022-05-03T19:01:56.469Z,"30 km NNW of Shahrak-e P?bed?n?, Iran",earthquake,6.9,1.8,0.065,23,reviewed,us,us
+2017-12-12T21:49:41.590Z,30.8681,57.2454,10,5,mb,,38,5.485,0.61,us,us2000c3ms,2022-05-03T18:43:04.836Z,"60 km SE of R?var, Iran",earthquake,8.4,1.9,0.071,63,reviewed,us,us
+2017-12-12T21:41:31.140Z,30.8275,57.2982,8,6,mww,,24,5.477,0.78,us,us2000c3mi,2022-08-07T22:08:55.465Z,"63 km NNE of Kerman, Iran",earthquake,7.2,1.8,0.05,38,reviewed,us,us
+2017-12-12T08:43:18.320Z,30.7372,57.2795,12,6,mww,,49,5.549,0.79,us,us2000c3ag,2022-05-03T19:52:39.469Z,"53 km NNE of Kerman, Iran",earthquake,7.3,1.8,0.052,35,reviewed,us,us
+2017-12-11T14:09:57.360Z,35.0786,45.7614,17.55,5.4,mww,,43,0.051,0.66,us,us2000c2ue,2022-05-03T18:42:41.612Z,"23 km WSW of ?alabja, Iraq",earthquake,5.7,2.8,0.071,19,reviewed,us,us
+2017-12-02T10:47:04.040Z,30.7254,57.3614,10,5.2,mww,,38,5.505,0.66,us,us1000bk9a,2022-08-07T21:49:29.233Z,"56 km NNE of Kerman, Iran",earthquake,7.4,1.8,0.086,13,reviewed,us,us
+2017-12-01T03:35:01.840Z,30.7151,57.385,10,5.4,mww,,46,5.498,0.82,us,us1000bjq8,2022-05-03T19:01:46.514Z,"56 km NNE of Kerman, Iran",earthquake,7.4,1.8,0.075,17,reviewed,us,us
+2017-12-01T02:43:27.200Z,30.6973,57.4397,10,5.1,mb,,49,5.475,0.96,us,us1000bjp3,2022-05-03T18:41:22.399Z,"57 km NE of Kerman, Iran",earthquake,4.1,1.8,0.056,105,reviewed,us,us
+2017-12-01T02:32:46.040Z,30.7464,57.307,9,6.1,mww,,23,5.526,0.89,us,us1000bjnz,2022-08-07T21:46:20.750Z,"55 km NNE of Kerman, Iran",earthquake,7.1,1.7,0.06,27,reviewed,us,us
+2017-11-24T21:49:15.170Z,37.0845,28.6223,5.17,5.2,mww,,26,0.958,0.75,us,us2000bu6g,2022-05-03T19:01:41.414Z,"18 km E of Ula, Turkey",earthquake,3.6,3.5,0.068,21,reviewed,us,us
+2017-11-22T20:22:53.540Z,37.0511,28.6427,10,5.1,mww,,24,0.935,0.82,us,us2000bt6a,2022-08-07T21:26:59.159Z,"20 km ESE of Ula, Turkey",earthquake,5.1,1,0.063,24,reviewed,us,us
+2017-11-20T15:23:42.720Z,32.8531,46.3892,35,5.1,mb,,64,2.325,0.91,us,us2000bruq,2022-05-03T18:40:55.083Z,"36 km SE of Mehr?n, Iran",earthquake,5.7,1.8,0.049,137,reviewed,us,us
+2017-11-15T19:48:03.560Z,40.3082,47.3317,22.13,5.2,mww,,40,1.989,1.24,us,us2000bp3f,2022-08-07T21:15:51.129Z,Azerbaijan,earthquake,5.3,3.8,0.062,25,reviewed,us,us
+2017-11-12T18:29:52.130Z,34.9224,45.5873,10,5.3,mb,,65,0.694,0.94,us,us2000bme6,2018-02-06T02:45:30.040Z,"46 km SW of ?alabja, Iraq",earthquake,5.2,1.9,0.15,15,reviewed,us,us
+2017-11-12T18:18:17.180Z,34.9109,45.9592,19,7.3,mww,,33,0.284,1.29,us,us2000bmcg,2022-05-03T20:02:36.492Z,"29 km S of ?alabja, Iraq",earthquake,4.9,1.7,0.044,50,reviewed,us,us
+2017-10-18T14:37:18.770Z,31.1369,54.8505,10,5,mb,,40,6.283,0.87,us,us1000atqg,2022-08-07T20:07:38.151Z,"62 km SE of Mahr?z, Iran",earthquake,7.6,1.9,0.06,87,reviewed,us,us
+2017-10-11T22:49:44.820Z,39.1647,24.2379,11.54,5.1,mww,,31,1.487,0.74,us,us1000aqij,2022-05-03T19:01:14.091Z,"32 km E of Patitírion, Greece",earthquake,5.5,3.8,0.062,25,reviewed,us,us
+2017-09-20T00:08:15.740Z,30.7208,57.4066,10,5,mb,,48,5.48,0.66,us,us2000ardv,2022-05-03T18:37:18.779Z,"57 km NNE of Kerman, Iran",earthquake,7.6,1.8,0.05,126,reviewed,us,us
+2017-09-11T16:20:15.920Z,39.2104,21.5733,10,5,mb,,62,0.622,1.02,us,us2000ak65,2022-08-07T17:07:39.862Z,"18 km SSE of Anthiró, Greece",earthquake,4.7,1.7,0.04,198,reviewed,us,us
+2017-08-27T23:14:52.810Z,37.9475,47.1318,17.29,5.2,mwr,,44,2.669,0.86,us,us2000acc8,2022-08-07T15:49:54.142Z,"52 km N of Hashtr?d, Iran",earthquake,5.2,3.3,0.08,15,reviewed,us,us
+2017-08-23T13:42:53.880Z,36.1833,44.9358,8,5.1,mww,,43,0.7,0.8,us,us2000aay1,2022-08-07T15:28:42.195Z,"29 km ENE of Koysinceq, Iraq",earthquake,5.8,1.8,0.083,14,reviewed,us,us
+2017-08-08T07:42:22.230Z,36.9645,27.5711,10,5.3,mww,,38,0.87,0.69,us,us2000a5vf,2022-08-07T14:09:13.560Z,"15 km ESE of Bodrum, Turkey",earthquake,4.2,1.8,0.065,23,reviewed,us,us
+2017-07-31T21:29:14.690Z,34.5158,24.0577,39.02,5.3,mww,,43,1.03,0.8,us,us2000a30v,2022-08-07T13:22:18.784Z,"35 km S of Kastrí, Greece",earthquake,7,5.7,0.083,14,reviewed,us,us
+2017-07-30T15:37:40.130Z,31.8161,50.597,10,5,mb,,58,5.72,0.58,us,us2000a2q6,2022-08-07T13:14:54.482Z,"49 km S of F?rs?n, Iran",earthquake,6.4,1.3,0.044,162,reviewed,us,us
+2017-07-23T17:32:14.200Z,30.1823,57.6157,10,5.2,mww,,76,5.365,0.98,us,us2000a03u,2022-08-07T12:41:47.659Z,"52 km ESE of Kerman, Iran",earthquake,5.1,1.8,0.069,20,reviewed,us,us
+2017-07-21T17:09:45.290Z,36.9074,27.3012,10,5,mww,,40,0.956,1.34,us,us20009zaf,2022-08-07T12:30:58.419Z,"2 km NE of Kos, Greece",earthquake,4.8,1.8,0.073,18,reviewed,us,us
+2017-07-20T22:31:11.260Z,36.9293,27.4139,7,6.6,mww,,16,0.913,0.78,us,us20009ynd,2022-05-12T18:38:26.907Z,"11 km ENE of Kos, Greece",earthquake,4.3,1.7,0.058,29,reviewed,us,us
+2017-07-15T20:30:17.110Z,34.925,25.4294,9.93,5.3,mww,,39,0.571,0.6,us,us20009wn5,2022-08-07T11:59:33.079Z,"23 km WSW of Néa Anatolí, Greece",earthquake,3.8,3.4,0.066,22,reviewed,us,us
+2017-06-17T19:50:04.790Z,38.8864,26.4186,7.74,5.2,mww,,28,1.72,0.69,us,us20009nb8,2022-05-03T18:59:47.098Z,"10 km SSE of Plomári, Greece",earthquake,4.9,3.5,0.041,58,reviewed,us,us
+2017-06-12T12:28:39.150Z,38.9296,26.365,12,6.3,mww,,55,1.77,0.76,us,us20009ly0,2022-05-03T19:52:27.633Z,"5 km S of Plomári, Greece",earthquake,5.3,1.7,0.035,78,reviewed,us,us
+2017-05-27T15:53:24.250Z,38.7729,27.8234,10,5.1,mwr,,24,0.64,1.06,us,us10008vt5,2022-05-03T18:30:29.818Z,"10 km NW of Gölmarmara, Turkey",earthquake,4.7,1.8,0.066,22,reviewed,us,us
+2017-05-13T18:00:59.520Z,37.7693,57.2058,8,5.6,mww,,36,0.738,1.12,us,us10008s7b,2022-05-03T18:29:33.945Z,"34 km NNW of Bojn?rd, Iran",earthquake,5.5,1.8,0.069,20,reviewed,us,us
+2017-05-11T17:58:02.740Z,40.0382,40.7422,13.43,5.1,mb,,30,0.189,0.72,us,us10008riw,2017-08-01T23:02:30.040Z,"13 km NNE of A?kale, Turkey",earthquake,4.7,3.4,0.035,270,reviewed,us,us
+2017-05-11T03:24:21.370Z,39.8156,48.5695,62.93,5.1,mb,,38,2.96,0.86,us,us10008re3,2022-05-03T18:27:05.113Z,"16 km ESE of ?hm?db?yli, Azerbaijan",earthquake,7.3,5.4,0.05,130,reviewed,us,us
+2017-05-03T08:53:37.190Z,42.175,46.9611,10,5.2,mb,,27,2.628,1.4,us,us10008nrz,2022-05-03T18:59:08.287Z,"12 km ESE of Tsurib, Russia",earthquake,6.5,1.8,0.031,337,reviewed,us,us
+2017-05-02T21:12:11.090Z,35.8339,60.5704,10,5.1,mb,,53,1.991,0.6,us,us10008nl9,2022-05-03T18:25:49.282Z,"65 km N of Torbat-e J?m, Iran",earthquake,6.5,1.8,0.047,147,reviewed,us,us
+2017-04-21T13:09:22.060Z,38.7709,29.0638,10,5,mb,,31,0.485,0.92,us,us10008ji3,2022-05-03T18:16:25.559Z,"17 km E of Selendi, Turkey",earthquake,2.8,1.8,0.057,100,reviewed,us,us
+2017-04-13T16:22:16.250Z,37.1253,28.6913,10,5,mwr,,31,1.018,0.9,us,us10008hbd,2022-05-03T18:15:41.556Z,"24 km E of Ula, Turkey",earthquake,5.2,1.8,0.061,26,reviewed,us,us
+2017-04-05T20:07:25.820Z,35.7971,60.4318,10,5.1,mb,,40,2.824,0.93,us,us10008er2,2022-05-03T18:15:27.077Z,"63 km NNW of Torbat-e J?m, Iran",earthquake,7.3,1.8,0.038,224,reviewed,us,us
+2017-04-05T06:09:12.200Z,35.7755,60.4363,13,6.1,mww,,43,2.029,1.07,us,us10008ei0,2022-05-03T19:41:10.926Z,"61 km NNW of Torbat-e J?m, Iran",earthquake,4.9,1.7,0.05,38,reviewed,us,us
+2017-03-02T11:07:26.880Z,37.616,38.4305,10,5.6,mww,,30,1.068,0.61,us,us100086gw,2022-05-03T18:11:51.848Z,"5 km NW of Samsat, Turkey",earthquake,5,1,0.056,31,reviewed,us,us
+2017-02-12T13:48:16.090Z,39.6004,26.0884,6.01,5.3,mww,,41,1.294,0.52,us,us20008jcc,2022-05-03T18:11:14.317Z,"24 km WNW of Behram, Turkey",earthquake,4.9,3.6,0.055,32,reviewed,us,us
+2017-02-07T02:24:04.150Z,39.5279,26.0993,8.38,5.3,mww,,33,1.366,0.62,us,us20008i2k,2022-05-03T18:10:57.614Z,"18 km NNW of Míthymna, Greece",earthquake,4.4,3.5,0.046,46,reviewed,us,us
+2017-02-06T10:58:02.270Z,39.5734,26.0755,7.21,5.2,mww,,33,1.32,1.01,us,us20008hwm,2022-05-03T18:10:46.472Z,"23 km WNW of Behram, Turkey",earthquake,4.4,3.5,0.061,26,reviewed,us,us
+2017-02-06T03:51:40.640Z,39.5986,26.0647,10,5.3,mww,,33,1.295,0.65,us,us20008hv1,2022-05-03T18:12:03.225Z,"25 km WNW of Behram, Turkey",earthquake,4.5,1.7,0.047,43,reviewed,us,us
+2017-02-05T15:59:09.040Z,39.2982,54.7342,10,5,mb,,51,7.749,0.58,us,us20008hsv,2017-05-09T01:24:27.040Z,"16 km NE of Gumdag, Turkmenistan",earthquake,5.6,1.8,0.044,166,reviewed,us,us
+2017-02-05T13:46:25.700Z,39.258,54.8155,10,5.2,mb,,45,7.818,0.83,us,us20008hsc,2017-05-09T01:24:27.040Z,"20 km ENE of Gumdag, Turkmenistan",earthquake,7.4,1.8,0.041,191,reviewed,us,us
+2017-01-25T18:50:51.790Z,35.3583,26.4196,56.63,5.2,mww,,41,1.252,0.91,us,us10007vdu,2017-04-19T18:31:00.040Z,"23 km NE of Palekastro, Greece",earthquake,5.6,5.2,,,reviewed,us,us
+2017-01-18T13:33:38.000Z,42.5581,13.2487,7.39,5.2,mww,,33,0.12,0.6,us,us10007txl,2022-05-03T18:14:23.688Z,"3 km N of Montereale, Italy",earthquake,5.2,3.8,,,reviewed,us,us
+2017-01-18T10:25:25.490Z,42.5855,13.1904,10,5.6,mww,,30,0.169,0.55,us,us10007twn,2022-05-03T18:09:16.530Z,"4 km SE of Cittareale, Italy",earthquake,5.2,1.8,,,reviewed,us,us
+2017-01-18T10:14:10.980Z,42.6012,13.2268,7,5.7,mww,,27,0.149,0.55,us,us10007twj,2023-02-16T07:48:26.205Z,"5 km ESE of Cittareale, Italy",earthquake,5.2,1.8,,,reviewed,us,us
+2017-01-18T09:25:41.610Z,42.6598,13.2099,10,5.3,mww,,30,0.462,0.84,us,us10007twc,2017-04-12T02:29:00.040Z,"4 km SW of Accumoli, Italy",earthquake,5.1,1.8,,,reviewed,us,us
+2016-12-27T23:20:56.100Z,45.7144,26.5283,97,5.6,mww,,14,0.466,0.8,us,us10007n3r,2022-05-03T18:56:39.273Z,"13 km W of Nereju Mic, Romania",earthquake,4.3,1.8,,,reviewed,us,us
+2016-12-20T06:03:44.240Z,36.5393,26.9187,129.94,5.4,mb,,39,1.009,1.13,us,us200082q4,2017-03-16T02:31:30.040Z,"Dodecanese Islands, Greece",earthquake,5.9,5.3,0.027,453,reviewed,us,us
+2016-10-30T06:40:18.670Z,42.8621,13.0961,8,6.6,mww,,25,0.174,0.67,us,us1000731j,2023-02-16T07:47:12.705Z,"5 km ESE of Preci, Italy",earthquake,5.3,1.8,,,reviewed,us,us
+2016-10-28T20:02:49.760Z,39.3881,13.5205,457.86,5.8,mww,,17,1.822,0.76,us,us100072su,2022-05-03T18:02:48.400Z,"80 km NNE of Ustica, Italy",earthquake,8,3.6,,,reviewed,us,us
+2016-10-26T19:18:08.430Z,42.9564,13.0666,10,6.1,mww,,17,0.081,0.71,us,us1000725y,2023-02-16T07:45:45.893Z,"2 km NNW of Visso, Italy",earthquake,4.7,1.7,,,reviewed,us,us
+2016-10-26T17:10:37.210Z,42.858,13.0528,6,5.5,mww,,32,0.051,0.88,us,us20007guy,2023-02-16T07:43:39.129Z,"2 km SSE of Preci, Italy",earthquake,4.4,1.7,,,reviewed,us,us
+2016-10-26T14:15:40.610Z,39.4848,54.5087,26,5.4,mww,,42,3.221,0.73,us,us20007guj,2022-05-03T18:55:46.931Z,"12 km ESE of Balkanabat, Turkmenistan",earthquake,7,1.9,,,reviewed,us,us
+2016-10-16T02:21:04.030Z,39.7866,20.6113,19.45,5,mww,,42,0.632,0.76,us,us20007egg,2022-05-03T18:55:37.141Z,"10 km WSW of Asprángeloi, Greece",earthquake,5.2,2.5,,,reviewed,us,us
+2016-10-16T00:41:14.360Z,39.8168,20.5912,13.3,5.2,mww,,35,0.347,0.94,us,us20007efm,2022-05-03T18:01:58.690Z,"8 km SSW of Kalpáki, Greece",earthquake,5,3.7,,,reviewed,us,us
+2016-10-16T00:09:58.160Z,39.7659,20.7143,10,5,mb,,38,0.709,0.79,us,us20007efi,2017-01-15T01:13:54.040Z,"6 km S of Asprángeloi, Greece",earthquake,4.5,1.8,0.051,124,reviewed,us,us
+2016-10-15T20:14:49.730Z,39.8063,20.6463,22,5.5,mww,,26,0.661,0.85,us,us20007eec,2022-05-03T18:01:57.550Z,"7 km WSW of Asprángeloi, Greece",earthquake,4.6,1.8,,,reviewed,us,us
+2016-10-15T08:18:32.870Z,42.2088,30.7242,6.4,5.1,mww,,22,1.772,0.84,us,us20007ebw,2017-01-15T01:13:52.040Z,"117 km NNW of Ere?li, Turkey",earthquake,5.6,4.1,,,reviewed,us,us
+2016-09-28T07:17:35.820Z,36.7738,21.912,46.53,5,mb,,66,0.404,0.83,us,us10006th7,2016-12-14T03:17:54.040Z,"4 km WSW of Koróni, Greece",earthquake,6.8,7.9,0.045,159,reviewed,us,us
+2016-09-27T20:57:08.120Z,36.3888,27.6141,85.2,5.1,mww,,32,0.445,0.95,us,us10006td4,2016-12-14T03:17:53.040Z,"28 km NW of Émponas, Greece",earthquake,4.7,3.7,,,reviewed,us,us
+2016-09-23T23:11:20.810Z,45.7275,26.6097,92,5.6,mww,,10,0.307,0.96,us,us10006s5c,2022-05-03T18:00:19.211Z,"7 km WNW of Nereju Mic, Romania",earthquake,4,1.8,,,reviewed,us,us
+2016-09-11T13:10:08.070Z,42.0081,21.4876,13.2,5.1,mww,,17,1.384,0.57,us,us10006nuj,2022-05-03T17:58:48.922Z,"3 km ESE of ?air, North Macedonia",earthquake,4.6,3.4,,,reviewed,us,us
+2016-08-24T02:33:29.450Z,42.8413,13.1533,3.25,5.6,mww,,23,0.521,0.84,us,us10006g7w,2022-05-03T18:41:12.095Z,"5 km S of Castelsantangelo sul Nera, Italy",earthquake,3.9,2.1,,,reviewed,us,us
+2016-08-24T01:36:32.870Z,42.723,13.1877,4.44,6.2,mww,,25,0.123,0.68,us,us10006g7d,2023-02-16T07:41:12.866Z,"5 km WNW of Accumoli, Italy",earthquake,4.4,2.8,,,reviewed,us,us
+2016-08-01T04:46:34.530Z,39.9542,47.976,16,5,mwb,,37,2.49,0.95,us,us1000693d,2022-05-03T17:56:43.690Z,"11 km NW of Imishli, Azerbaijan",earthquake,6.3,1.8,0.075,17,reviewed,us,us
+2016-07-30T17:26:22.250Z,35.2905,22.9493,23.39,5.2,mb,,25,1.587,1.18,us,us100068tv,2016-10-19T04:51:51.040Z,"66 km W of Palaióchora, Greece",earthquake,6.3,4,0.026,473,reviewed,us,us
+2016-05-25T08:36:13.730Z,34.9521,26.2106,10,5.3,mww,,42,0.978,1.28,us,us20005xrv,2022-08-02T23:52:17.910Z,"27 km S of Palekastro, Greece",earthquake,5.6,1.8,,,reviewed,us,us
+2016-04-16T00:10:41.290Z,34.9371,25.7577,10,5,mwr,,42,0.792,0.72,us,us20005ivy,2022-05-03T18:51:25.395Z,"8 km S of Ierápetra, Greece",earthquake,7.1,1.9,0.05,39,reviewed,us,us
+2016-04-03T00:46:15.800Z,34.19,25.73,9,5.1,mb,,,,0.99,us,us20005e7c,2016-06-17T21:45:11.040Z,"91 km S of Néa Anatolí, Greece",earthquake,5.4,3.3,0.042,186,reviewed,ath,us
+2016-03-29T01:05:29.990Z,37.5169,20.1644,10.34,5.4,mww,,36,1.443,0.98,us,us20005d34,2022-08-02T16:09:17.169Z,"62 km SW of Katastárion, Greece",earthquake,5.3,3.7,,,reviewed,us,us
+2016-02-15T18:55:02.030Z,37.5665,21.7826,28.63,5.3,mww,,37,0.403,1.13,us,us200050cf,2022-08-07T09:41:52.668Z,"14 km E of Kréstena, Greece",earthquake,5.5,4,,,reviewed,us,us
+2016-01-10T17:40:49.510Z,39.5649,34.3373,10,5,mwr,,42,0.562,0.85,us,us10004dbv,2022-08-07T08:46:20.255Z,"13 km SW of Yerköy, Turkey",earthquake,3.7,1.4,0.053,34,reviewed,us,us
+2015-12-26T11:00:52.980Z,35.5164,27.3862,36.79,5.2,mww,,41,1.781,1.13,us,us100049m3,2022-08-02T01:02:36.507Z,"15 km E of Karpathos, Greece",earthquake,6.1,5.2,,,reviewed,us,us
+2015-12-02T23:27:09.890Z,39.2826,40.2553,10,5.4,mww,,13,0.272,0.71,us,us100042v4,2022-08-01T21:35:37.339Z,"17 km ENE of Yayladere, Turkey",earthquake,4.1,1.7,,,reviewed,us,us
+2015-11-25T21:17:18.500Z,31.892,49.54,12,5.4,mb,,,,0.76,us,us100041c9,2022-08-01T20:18:38.215Z,"22 km ESE of Masjed Soleym?n, Iran",earthquake,4.9,3.5,0.04,214,reviewed,teh,us
+2015-11-18T12:15:37.950Z,38.8407,20.5551,10,5,mww,,54,1.4,0.96,us,us10003z89,2022-05-03T19:21:36.547Z,"13 km W of Lefkáda, Greece",earthquake,3.1,1.8,,,reviewed,us,us
+2015-11-17T08:33:40.800Z,38.65,20.56,9,5.1,mww,,,,0.91,us,us10003ywz,2016-02-13T02:08:26.040Z,"23 km SSW of Lefkáda, Greece",earthquake,4.9,2.3,,,reviewed,ath,us
+2015-11-17T07:10:07.300Z,38.67,20.6,11,6.5,mww,,,,0.98,us,us10003ywp,2022-08-01T18:14:50.537Z,"19 km SSW of Lefkáda, Greece",earthquake,4.6,3,,,reviewed,ath,us
+2015-10-09T14:39:15.000Z,40.6847,36.6897,5,5.1,mwr,,,,0.99,us,us10003mgj,2022-08-01T10:16:46.355Z,"10 km E of Erbaa, Turkey",earthquake,5.3,1.9,0.047,43,reviewed,isk,us
+2015-10-06T21:27:33.000Z,36.1682,29.8952,22.4,5.2,mww,,,,0.87,us,us10003ksq,2022-08-01T09:52:32.618Z,"11 km SW of Demre, Turkey",earthquake,5.6,3.6,,,reviewed,isk,us
+2015-09-04T04:49:38.520Z,40.9329,47.5328,13.96,5.4,mww,,27,2.267,1.01,us,us20003g7a,2022-08-01T03:32:00.872Z,"16 km SSE of O?uz, Azerbaijan",earthquake,6.4,3.6,,,reviewed,us,us
+2015-08-18T21:19:44.530Z,35.6473,31.2871,47.26,5,mww,,45,1.484,0.77,us,us1000339b,2022-08-01T00:41:19.322Z,"115 km SW of Gazipa?a, Turkey",earthquake,5.1,4.8,,,reviewed,us,us
+2015-07-31T10:06:31.380Z,30.0391,57.5809,11,5.2,mwb,,55,0.181,0.74,us,us10002wtx,2022-07-31T21:45:24.663Z,"55 km ESE of Kerman, Iran",earthquake,4.4,1.8,0.068,21,reviewed,us,us
+2015-07-24T09:58:38.280Z,36.703,26.8098,140.62,5.1,mb,,55,1.137,0.72,us,us20002zt0,2022-07-31T20:22:45.338Z,"14 km WSW of Kéfalos, Greece",earthquake,6.2,5.7,0.031,338,reviewed,us,us
+2015-06-20T19:52:43.900Z,34.3082,26.2262,15.25,5,mb,,45,0.804,0.86,us,us10002kjx,2015-09-01T00:53:52.040Z,"89 km SSE of Ierápetra, Greece",earthquake,5.7,3.3,0.041,186,reviewed,us,us
+2015-06-09T21:49:46.700Z,35.04,26.79,16,5.4,mww,,,,1.07,us,us20002ney,2022-07-31T12:09:35.548Z,"43 km SSW of Fry, Greece",earthquake,5,3,,,reviewed,ath,us
+2015-06-09T01:09:03.000Z,38.62,23.39,13,5.3,mww,,,,0.26,us,us20002n56,2022-05-03T18:49:58.938Z,"13 km E of Malesína, Greece",earthquake,3.8,3.5,,,reviewed,ath,us
+2015-05-05T21:28:30.700Z,35.321,58.409,8.6,5,mb,,,,0.89,us,us20002c1u,2022-05-03T17:21:23.837Z,"10 km NNW of K?shmar, Iran",earthquake,4.3,3.2,0.062,82,reviewed,teh,us
+2015-05-02T08:23:46.300Z,34.45,25.78,13,5,mb,,,,0.8,us,us20002au8,2015-07-09T22:00:06.040Z,"62 km S of Ierápetra, Greece",earthquake,6.8,2,0.048,138,reviewed,ath,us
+2015-04-17T02:05:40.330Z,35.0337,26.7848,15.38,5.3,mww,,49,0.597,0.83,us,us2000277l,2022-07-30T23:38:58.948Z,"44 km SSW of Fry, Greece",earthquake,3.9,2.5,,,reviewed,us,us
+2015-04-16T19:02:12.040Z,35.0647,26.8768,10,5,mb,,51,0.534,0.94,us,us20002732,2022-05-03T17:19:39.051Z,"39 km S of Fry, Greece",earthquake,6.4,1.8,0.037,236,reviewed,us,us
+2015-04-16T18:07:43.610Z,35.1891,26.8235,20,6,mww,,25,0.451,0.83,us,us2000272b,2022-07-30T23:31:19.684Z,"26 km SSW of Fry, Greece",earthquake,6,1.7,,,reviewed,us,us
+2015-04-15T08:25:11.630Z,34.8078,32.3311,10,5.3,mww,,46,0.836,1.09,us,us200026mv,2022-07-28T08:10:17.364Z,"6 km WSW of Kissonerga, Cyprus",earthquake,6.2,1.7,,,reviewed,us,us
+2015-03-27T23:34:54.300Z,35.7086,26.6225,66.96,5.2,mww,,41,0.467,1.01,us,us10001rdw,2022-07-28T04:54:26.848Z,"42 km NW of Fry, Greece",earthquake,6.2,4.7,,,reviewed,us,us
+2015-03-22T22:45:23.800Z,40.2724,52.074,32.4,5.1,mb,,42,5.25,0.56,us,us10001pn9,2022-05-03T17:15:56.572Z,"80 km WNW of Türkmenba?y, Turkmenistan",earthquake,6.4,4.2,0.037,244,reviewed,us,us
+2015-01-28T15:54:39.020Z,34.4562,25.0882,37,5.1,mww,,42,0.845,0.78,us,usb000tixk,2022-07-27T17:18:15.247Z,"61 km S of Pýrgos, Greece",earthquake,6.4,1.9,,,reviewed,us,us
+2015-01-26T03:30:15.230Z,41.2918,48.8748,50.12,5,mb,,37,3.342,1.32,us,usc000tj1y,2022-05-03T17:11:03.667Z,"13 km NW of Divichibazar, Azerbaijan",earthquake,6.9,5.6,0.055,109,reviewed,us,us
+2014-12-29T20:34:11.570Z,41.7007,19.2785,7.01,5,mb,,,,0.85,us,usc000tan7,2022-07-27T11:55:33.935Z,"25 km S of Ulcinj, Montenegro",earthquake,4.7,3.5,0.043,191,reviewed,tir,us
+2014-12-12T20:45:40.930Z,30.4132,50.4977,12.58,5.2,mb,,42,2.383,0.99,us,usc000t65g,2022-07-27T10:22:05.905Z,"29 km WNW of Dogonbadan, Iran",earthquake,5.9,2,0.041,204,reviewed,us,us
+2014-12-06T01:45:06.760Z,38.894,26.272,12.4,5.1,mww,,,,0.67,us,usc000t478,2022-07-27T09:42:28.610Z,"12 km SW of Plomári, Greece",earthquake,5.2,3.3,,,reviewed,isk,us
+2014-11-22T19:14:16.370Z,45.8977,27.1505,32,5.6,mww,,13,0.149,0.86,us,usb000sz38,2022-08-07T04:48:34.015Z,"5 km E of Panciu, Romania",earthquake,2.9,1.8,,,reviewed,us,us
+2014-11-17T23:09:04.450Z,38.6802,23.3105,10,5.1,mww,,38,0.833,1.01,us,usc000syb1,2022-05-03T17:06:47.177Z,"9 km NE of Malesína, Greece",earthquake,5.1,1.8,,,reviewed,us,us
+2014-11-17T23:05:58.440Z,38.6709,23.3782,23.29,5.4,mww,,32,0.885,0.78,us,usc000syak,2022-08-07T04:26:05.103Z,"11 km SSE of Límni, Greece",earthquake,4.1,3.7,,,reviewed,us,us
+2014-11-08T23:15:42.200Z,38.1,20.44,18,5.1,mww,,,,0.84,us,usc000svrp,2022-07-27T06:59:22.022Z,"9 km SSW of Argostólion, Greece",earthquake,5.1,3.2,,,reviewed,ath,us
+2014-11-07T07:41:38.300Z,38.1,20.44,18,5.1,mb,,,,0.88,us,usc000svav,2022-07-27T06:48:31.461Z,"9 km SSW of Argostólion, Greece",earthquake,3.1,3.3,0.049,147,reviewed,ath,us
+2014-10-24T23:43:15.500Z,38.9193,21.1252,0.1,5.3,mww,,,,1.09,us,usb000sqgd,2022-07-27T05:46:39.618Z,"5 km WSW of Kríkellos, Greece",earthquake,5.4,1,,,reviewed,the,us
+2014-10-15T13:35:52.840Z,32.5273,47.8065,10,5.7,mww,,44,6.951,0.65,us,usb000smff,2022-07-27T04:59:13.063Z,"53 km ESE of Dehlor?n, Iran",earthquake,6.9,1.7,,,reviewed,us,us
+2014-10-03T22:20:45.530Z,34.4354,26.3013,15.49,5.1,mww,,42,1.314,0.79,us,usb000simv,2022-05-03T18:18:30.132Z,"81 km SE of Ierápetra, Greece",earthquake,6.2,3.6,,,reviewed,us,us
+2014-09-29T01:38:08.090Z,41.1965,48.1004,13.23,5.3,mb,,19,3.477,1.19,us,usb000sgya,2022-07-27T03:22:02.417Z,"29 km SSE of Usukhchay, Russia",earthquake,5.3,3.5,0.032,346,reviewed,us,us
+2014-09-21T00:43:40.000Z,38.3508,21.8327,11.4,5,mww,,,,0.76,us,usb000selq,2022-07-27T02:34:59.987Z,"4 km S of Náfpaktos, Greece",earthquake,4.8,3.4,,,reviewed,the,us
+2014-09-04T21:00:04.300Z,36.21,30.82,46,5.3,mww,,,,0.94,us,usb000s99n,2022-07-27T00:44:28.952Z,"41 km SE of Tekirova, Turkey",earthquake,5.2,4.5,,,reviewed,isk,us
+2014-08-31T14:44:34.110Z,33.6233,45.8027,10,5,mb,,69,5.18,0.7,us,usc000s8hi,2022-05-03T17:00:13.151Z,"26 km ESE of Mandal?, Iraq",earthquake,7.5,1.8,0.048,151,reviewed,us,us
+2014-08-29T03:45:07.500Z,36.685,23.706,80,5.8,mww,,,,0.97,us,usc000s7wh,2022-07-27T00:05:47.063Z,"59 km E of Géfyra, Greece",earthquake,6.2,4.1,,,reviewed,the,us
+2014-08-24T19:43:30.750Z,37.683,30.6288,7.4,5.1,mww,,,,1.09,us,usb000s5w4,2022-08-07T01:19:20.591Z,"9 km ENE of A?lasun, Turkey",earthquake,5.1,3.6,,,reviewed,isk,us
+2014-08-24T02:44:52.100Z,32.682,47.792,19.4,5.2,mb,,,,1.22,us,usb000s5sb,2022-05-03T16:59:35.002Z,"48 km SE of ?bd?n?n, Iran",earthquake,5.1,3.3,0.042,208,reviewed,teh,us
+2014-08-23T20:05:18.700Z,32.716,47.774,19.6,5.1,mwb,,,,0.56,us,usb000s5qt,2022-07-26T23:08:23.548Z,"45 km SE of ?bd?n?n, Iran",earthquake,5.9,3.4,0.054,33,reviewed,teh,us
+2014-08-22T20:06:04.240Z,33.7003,45.7728,17.1,5.1,mwb,,47,5.1,0.98,us,usb000s5h3,2022-07-26T23:01:33.892Z,"20 km ESE of Mandal?, Iraq",earthquake,7.2,3.3,0.098,10,reviewed,us,us
+2014-08-22T04:27:54.000Z,39.935,23.431,13.5,5.2,mww,,,,1.08,us,usb000s57w,2022-08-07T01:16:34.048Z,"12 km S of Kassándreia, Greece",earthquake,4.4,3.4,,,reviewed,the,us
+2014-08-20T10:14:15.700Z,32.636,47.736,17.7,5.6,mwb,,,,0.85,us,usb000s4if,2022-05-03T18:17:49.436Z,"44 km E of Dehlor?n, Iran",earthquake,4,3.4,0.04,59,reviewed,teh,us
+2014-08-19T21:32:16.400Z,32.74,47.525,7.8,5.4,mb,,,,0.76,us,usb000s4e8,2022-05-03T18:32:00.837Z,"24 km ENE of Dehlor?n, Iran",earthquake,,3.3,0.035,298,reviewed,teh,us
+2014-08-18T18:09:05.550Z,32.5365,47.7673,10,5.1,mb,,76,9.203,0.99,us,usc000s829,2014-11-15T04:07:15.000Z,"50 km ESE of Dehlor?n, Iran",earthquake,,1.7,0.404,12,reviewed,us,us
+2014-08-18T18:08:22.750Z,32.5827,47.7037,5,6,mww,,29,6.858,0.63,us,usb000s3t7,2022-07-26T22:39:15.231Z,"42 km ESE of Dehlor?n, Iran",earthquake,,1.7,,,reviewed,us,us
+2014-08-18T11:51:35.000Z,32.78,47.68,10,5.4,mwc,,,,1.27,us,usb000s3qn,2022-05-03T18:33:49.948Z,"33 km SE of ?bd?n?n, Iran",earthquake,,3.4,,,reviewed,teh,gcmt
+2014-08-18T11:23:04.200Z,32.7,47.62,15,5.2,mb,,,,1.26,us,usb000s3qj,2022-05-03T16:59:06.786Z,"33 km E of Dehlor?n, Iran",earthquake,,2.8,0.05,136,reviewed,teh,us
+2014-08-18T05:25:51.000Z,32.72,47.69,12,5.6,mwb,,,,1.19,us,usb000s3ph,2022-07-26T22:37:14.023Z,"39 km SE of ?bd?n?n, Iran",earthquake,,3,0.048,42,reviewed,teh,us
+2014-08-18T02:32:05.350Z,32.703,47.695,10.2,6.2,mww,,,,0.46,us,usb000s3np,2022-07-26T22:35:15.173Z,"40 km E of Dehlor?n, Iran",earthquake,,3,,,reviewed,teh,us
+2014-08-17T14:47:20.300Z,32.7,47.64,16,5,mb,,,,0.95,us,usb000s3k2,2014-11-15T04:07:12.000Z,"34 km E of Dehlor?n, Iran",earthquake,,1.8,0.052,124,reviewed,thr,us
+2014-06-29T17:26:12.250Z,41.6028,46.6653,33.59,5,mb,,39,1.449,1.05,us,usc000rnkx,2022-07-26T18:35:09.411Z,"3 km SSE of Zaqatala, Azerbaijan",earthquake,,4.6,0.066,75,reviewed,us,us
+2014-06-11T03:53:40.640Z,34.7176,28.5028,75.19,5,mb,,48,1.376,0.85,us,usc000rdrr,2014-09-12T15:47:11.000Z,"146 km SE of Karpathos, Greece",earthquake,,4.6,0.033,295,reviewed,us,us
+2014-06-07T06:05:29.910Z,40.3731,51.5739,30.51,5.5,mwc,,37,5.64,0.74,us,usc000rcf1,2022-07-26T16:38:51.991Z,"106 km E of Pirallah?, Azerbaijan",earthquake,,3.3,,,reviewed,us,gcmt
+2014-06-01T12:05:51.900Z,34.7337,24.6177,30.6,5.1,mb,,,,0.95,us,usc000r9tn,2022-07-26T16:11:47.936Z,"40 km SSW of Tympáki, Greece",earthquake,,4.1,0.04,209,reviewed,ath,us
+2014-05-24T09:25:02.440Z,40.2893,25.3889,6.43,6.9,mww,,25,0.402,0.67,us,usb000r2hc,2022-08-06T23:56:04.427Z,"21 km SSW of Kamariótissa, Greece",earthquake,,3.2,,,reviewed,us,us
+2014-05-19T00:59:19.700Z,40.943,19.9057,10,5,mwr,,33,0.405,1.02,us,usb000qu5r,2022-07-26T15:14:53.291Z,"11 km SSW of Cërrik, Albania",earthquake,,1.8,0.068,21,reviewed,us,us
+2014-04-14T20:41:23.340Z,34.0995,25.866,12.3,5,mb,,110,1.432,0.71,us,usb000pkjt,2014-07-01T02:38:09.000Z,"101 km S of Ierápetra, Greece",earthquake,,4.7,0.047,152,reviewed,us,us
+2014-04-04T20:08:06.970Z,37.2833,23.8711,107,5.6,mww,,26,1.556,0.84,us,usc000p5r9,2022-07-26T12:13:59.385Z,"36 km ESE of Ýdra, Greece",earthquake,,1.8,,,reviewed,us,us
+2014-02-15T07:31:19.400Z,38.3001,20.3902,25.28,5,mb,,43,1.653,1.45,us,usc000mr39,2014-04-30T21:18:21.000Z,"11 km NNW of Lixoúri, Greece",earthquake,,4.3,0.047,159,reviewed,us,us
+2014-02-10T12:06:47.290Z,40.288,48.8033,64.66,5.4,mwb,,16,3.113,0.72,us,usc000mm4n,2022-08-06T21:43:39.214Z,"21 km N of Mughan, Azerbaijan",earthquake,,4.1,0.057,30,reviewed,us,us
+2014-02-03T03:08:46.190Z,38.2637,20.3897,5,6,mww,,,,1.26,us,usc000mfuh,2022-07-26T06:34:37.790Z,"8 km NNW of Lixoúri, Greece",earthquake,,1.6,,,reviewed,ath,us
+2014-01-26T18:45:07.920Z,38.2385,20.4178,21.7,5.4,mwr,,,,0.71,us,usb000m8gr,2022-05-03T18:03:27.571Z,"4 km NNW of Lixoúri, Greece",earthquake,,4.9,0.065,23,reviewed,ath,us
+2014-01-26T13:57:19.250Z,38.2889,20.5649,10,5.6,mb,,82,1.567,1,us,usc000mn0r,2022-05-03T16:45:08.314Z,"8 km WNW of Sámi, Greece",earthquake,,1.9,0.116,28,reviewed,us,us
+2014-01-26T13:55:42.210Z,38.2082,20.4528,8,6.1,mww,,36,1.555,0.81,us,usb000m8ch,2022-07-26T06:02:34.943Z,"1 km ENE of Lixoúri, Greece",earthquake,,1,,,reviewed,us,us
+2014-01-14T13:55:02.170Z,40.2807,52.8771,49.03,5.2,mb,,37,4.703,0.92,us,usb000m0r8,2022-05-03T16:37:34.621Z,"29 km NNW of Türkmenba?y, Turkmenistan",earthquake,,4.7,0.043,200,reviewed,us,us
+2014-01-11T04:12:56.200Z,37.827,20.95,0,5,mwr,,,,0.91,us,usc000m0t5,2022-05-03T18:03:20.559Z,"7 km NE of Zakynthos, Greece",earthquake,,1.8,0.071,19,reviewed,the,us
+2013-12-29T17:08:43.000Z,41.369,14.445,10.5,5.1,mwr,,,,1.05,us,usc000ltr4,2022-08-06T20:45:57.554Z,"5 km E of Castello del Matese, Italy",earthquake,,3.9,0.05,,reviewed,rom,us
+2013-12-28T15:21:04.090Z,36.028,31.31,40.7,5.9,mww,,26,1.34,1.08,us,usc000ltax,2022-07-26T04:08:12.104Z,"77 km SSW of Okurcalar, Turkey",earthquake,,3.3,,,reviewed,us,us
+2013-12-09T11:33:52.080Z,38.6028,55.5975,10,5.2,mb,,40,2.094,0.7,us,usb000le1j,2022-05-03T16:35:36.301Z,"71 km S of Bereket, Turkmenistan",earthquake,,1.8,0.055,,reviewed,us,us
+2013-11-24T20:49:38.670Z,40.8205,31.8691,5.99,5.1,mb,,25,0.588,1.14,us,usb000l5v1,2022-07-26T02:23:12.550Z,"14 km WNW of Yeniça?a, Turkey",earthquake,,4,0.06,,reviewed,us,us
+2013-11-24T18:05:41.670Z,34.1765,45.6171,14,5.4,mwb,,46,6.001,1.21,us,usb000l5tj,2022-07-26T02:22:06.412Z,"38 km SW of Sarpol-e Z?ah?b, Iran",earthquake,,1.8,0.046,,reviewed,us,us
+2013-11-24T18:03:13.030Z,34.1438,45.6274,10.78,5,mb,,48,6.034,1.1,us,usb000l5tg,2022-05-03T16:34:21.786Z,"41 km SSW of Sarpol-e Z?ah?b, Iran",earthquake,,2.6,0.061,,reviewed,us,us
+2013-11-23T23:26:20.600Z,34.2291,45.6639,10.06,5.2,mb,,34,5.953,0.8,us,usb000l5em,2022-05-03T16:34:11.069Z,"31 km SW of Sarpol-e Z?ah?b, Iran",earthquake,,1.7,0.041,,reviewed,us,us
+2013-11-22T18:30:58.010Z,34.3083,45.6105,14,5.8,mww,,28,0.75,0.9,us,usb000l4lf,2022-07-26T02:10:16.440Z,"28 km SW of Sarpol-e Z?ah?b, Iran",earthquake,,1.7,,,reviewed,us,us
+2013-11-22T06:51:25.060Z,34.4574,45.4824,6,5.6,mwb,,33,0.784,1.37,us,usb000l43r,2022-07-26T02:08:13.312Z,"34 km W of Sarpol-e Z?ah?b, Iran",earthquake,,1.2,0.038,,reviewed,us,us
+2013-10-12T13:11:53.350Z,35.5142,23.2523,40,6.6,mww,,40,1.984,1.21,us,usb000kbn7,2022-07-25T23:30:51.430Z,"36 km W of Kíssamos, Greece",earthquake,,1.9,,,reviewed,us,us
+2013-10-06T01:37:20.860Z,45.7013,26.5781,127,5.3,mww,,15,0.491,1.05,us,usb000k7k2,2022-08-06T18:12:43.701Z,"9 km W of Nereju Mic, Romania",earthquake,,1.8,,,reviewed,us,us
+2013-09-17T20:40:51.140Z,39.0234,41.4924,5.33,5,mb,,34,2.012,1.15,us,usc000jwi4,2022-05-03T16:26:38.548Z,"17 km S of Varto, Turkey",earthquake,,4.3,0.058,,reviewed,us,us
+2013-09-17T04:09:13.300Z,42.1462,45.8117,5,5.3,mwb,,33,0.902,0.83,us,usc000jw0j,2022-07-25T22:16:05.777Z,"21 km N of Q’vareli, Georgia",earthquake,,1.5,0.048,,reviewed,us,us
+2013-09-16T15:01:14.390Z,38.7062,22.729,7.7,5.3,mww,,37,0.22,0.64,us,usc000jvef,2022-05-03T17:51:07.383Z,"9 km NNW of Eláteia, Greece",earthquake,,1.7,,,reviewed,us_the,us
+2013-08-07T09:06:52.200Z,38.6885,22.6952,0.1,5.3,mwr,,20,0.24,0.95,us,usb000ixb7,2022-07-25T19:48:49.224Z,"9 km NW of Eláteia, Greece",earthquake,,3.1,0.061,,reviewed,us_the,us
+2013-07-21T01:32:24.000Z,43.501,13.668,8.4,5.4,mb,111,100,,,us,usb000iiu5,2022-07-25T18:42:59.988Z,"3 km ENE of Marcelli, Italy",earthquake,,,,278,reviewed,rom,us
+2013-06-16T21:43:15.210Z,34.326,24.998,10,5.1,mb,106,68,,1.17,us,usp000k19r,2014-11-07T01:51:05.263Z,"76 km S of Pýrgos, Greece",earthquake,,,,63,reviewed,us,us
+2013-06-16T21:39:05.780Z,34.347,25.159,19,6,mww,611,42,,0.87,us,usc000hsdj,2022-07-25T16:38:44.408Z,"73 km S of Pýrgos, Greece",earthquake,,,,,reviewed,us,us
+2013-06-15T16:11:02.500Z,34.4,25.02,10,6.2,mww,122,100,,,us,usc000hrl4,2022-07-25T16:33:25.966Z,"68 km S of Pýrgos, Greece",earthquake,,,,,reviewed,ath,us
+2013-06-06T11:53:47.060Z,36.815,21.869,39.4,5.1,mb,124,43,,1.07,us,usc000hh3y,2022-07-25T04:47:34.165Z,southern Greece,earthquake,,2.8,,236,reviewed,us,us
+2013-05-28T00:09:52.520Z,43.252,41.662,4.8,5.1,mwr,90,26,,1.4,us,usb000h78n,2022-07-25T03:27:14.820Z,"41 km WSW of Uchkulan, Russia",earthquake,,4.3,,,reviewed,us,us
+2013-05-23T14:09:05.900Z,38.659,20.564,6.9,5,mb,53,100,,,us,usb000h3bc,2022-07-25T02:49:29.075Z,"22 km SSW of Lefkáda, Greece",earthquake,,,,54,reviewed,the,us
+2013-04-09T03:36:27.510Z,36.488,23.032,18.9,5,mb,221,38.7,,1.06,us,usb000g2sh,2022-07-24T23:05:53.618Z,"22 km S of Géfyra, Greece",earthquake,,3.8,,135,reviewed,us,us
+2013-04-06T11:26:07.360Z,34.804,24.087,34.1,5.3,mb,341,41.1,,0.84,us,usb000g171,2022-07-24T22:43:25.407Z,"3 km S of Kastrí, Greece",earthquake,,3.7,,237,reviewed,us,us
+2013-03-26T23:35:24.540Z,43.219,41.637,10,5.1,mb,313,24.6,,0.81,us,usb000ftet,2014-11-07T01:50:23.685Z,"42 km N of Tqvarch'eli, Georgia",earthquake,,,,219,reviewed,us,us
+2013-02-17T05:42:07.750Z,36.678,21.68,32.2,5,mb,225,46,,1.23,us,usc000f8v6,2022-05-03T17:26:55.678Z,"15 km S of Methóni, Greece",earthquake,,7.1,,126,reviewed,us,us
+2013-01-25T12:11:27.920Z,31.769,50.913,37.7,5,mb,165,45.1,,0.99,us,usp000jytm,2022-05-03T16:04:10.807Z,"41 km WSW of Bor?jen, Iran",earthquake,,4.2,,101,reviewed,us,us
+2013-01-21T19:48:58.880Z,30.33,57.467,10,5.5,mwb,160,48.2,,0.99,us,usb000esbm,2022-07-24T15:56:32.712Z,"37 km E of Kerman, Iran",earthquake,,,,,reviewed,us,us
+2013-01-12T03:25:04.370Z,31.828,50.954,4.1,5.4,mb,262,29.7,,0.74,us,usp000jy92,2015-03-24T02:42:41.876Z,Western Iran,earthquake,,3.7,,153,reviewed,us,us
+2013-01-08T14:16:08.980Z,39.656,25.54,12.8,5.7,mww,487,14,,0.85,us,usp000jy2b,2022-05-03T16:03:03.238Z,"47 km ESE of Mýrina, Greece",earthquake,,2.3,,,reviewed,us,us
+2012-12-25T22:44:33.510Z,42.436,40.974,10,5.2,mwb,297,17,,1,us,usp000jxdg,2022-05-03T16:02:02.685Z,"50 km SSW of Dranda, Georgia",earthquake,,,,,reviewed,us,us
+2012-12-23T13:31:40.760Z,42.42,41.075,15.2,5.7,mww,415,19.7,,0.88,us,usp000jxaj,2022-05-03T16:01:54.925Z,"45 km SW of Och’amch’ire, Georgia",earthquake,,5.5,,,reviewed,us,us
+2012-12-23T06:38:57.450Z,38.458,44.868,12.4,5.2,mb,198,43.2,,0.89,us,usp000jxa7,2022-05-03T16:01:41.980Z,"12 km SW of Khowy, Iran",earthquake,,4,,131,reviewed,us,us
+2012-12-05T17:08:13.560Z,33.506,59.571,14.4,5.8,mww,248,20.2,,0.98,us,usp000jwga,2022-05-03T16:00:23.964Z,"43 km SE of Q?’en, Iran",earthquake,,9.6,,,reviewed,us,us
+2012-11-26T17:35:41.800Z,36.655,27.993,0,5,mb,237,31.9,,,us,usp000jw3s,2015-03-24T02:21:11.141Z,"14 km ENE of Sými, Greece",earthquake,,,,86,reviewed,the,us
+2012-11-07T06:26:32.840Z,38.418,46.62,10,5.4,mwb,301,29.8,,1.15,us,usp000jv4r,2022-05-03T15:56:11.498Z,"39 km W of Ahar, Iran",earthquake,,,,,reviewed,us,us
+2012-10-25T23:05:24.000Z,39.88,16.01,6,5.3,mww,334,13.6,,,us,usp000juew,2022-05-03T17:12:27.041Z,"2 km SE of Mormanno, Italy",earthquake,,,,,reviewed,rom,us
+2012-10-19T03:35:11.550Z,32.552,30.978,13.4,5.1,mb,174,44.2,,0.96,us,usp000ju5b,2022-03-10T00:17:21.119Z,"138 km NNE of Rosetta, Egypt",earthquake,,7.1,,80,reviewed,us,us
+2012-10-14T10:13:38.600Z,41.825,46.405,10,5.5,mwc,280,19.1,,1.01,us,usp000jtz4,2022-05-03T15:52:32.249Z,"10 km E of Lagodekhi, Georgia",earthquake,,,,,reviewed,us,gcmt
+2012-10-07T11:42:47.160Z,40.747,48.437,17.4,5.4,mb,373,26.1,,0.85,us,usp000jtpk,2022-05-03T15:51:31.407Z,"3 km ESE of Basqal, Azerbaijan",earthquake,,6.8,,269,reviewed,us,us
+2012-09-22T03:52:26.100Z,38.1,22.77,10,5,mww,573,24.6,,,us,usp000jspu,2022-05-03T15:50:25.365Z,"8 km NNE of Káto Dhiminió, Greece",earthquake,,,,,reviewed,the,us
+2012-09-21T08:47:40.090Z,35.3,22.63,16,5,mb,304,39.9,,,us,usp000jsnp,2014-11-07T01:48:53.382Z,"95 km WSW of Kíssamos, Greece",earthquake,,,,126,reviewed,ath,us
+2012-09-12T03:27:46.310Z,34.783,24.11,32.4,5.5,mww,590,41.2,,0.89,us,usp000js6n,2022-05-03T17:10:09.889Z,"6 km SSE of Kastrí, Greece",earthquake,,3.3,,,reviewed,us,us
+2012-09-02T00:50:00.500Z,33.474,59.897,12,5.1,mb,210,55.7,,,us,usp000jrfs,2022-05-03T15:49:13.922Z,"71 km ESE of Q?’en, Iran",earthquake,,,,97,reviewed,teh,us
+2012-08-15T17:49:04.600Z,38.41,46.672,4,5.3,mb,342,29.1,,,us,usp000jqbh,2022-05-03T15:46:24.146Z,"35 km WSW of Ahar, Iran",earthquake,,,,185,reviewed,teh,us
+2012-08-14T14:02:25.000Z,38.45,46.79,6,5.1,mb,281,36.9,,,us,usp000jqa5,2015-03-24T02:09:23.458Z,"24 km W of Ahar, Iran",earthquake,,,,144,reviewed,teh,us
+2012-08-11T22:24:02.000Z,38.482,46.759,4,5.1,mb,287,32.9,,,us,usp000jq6r,2022-05-03T15:45:57.780Z,"27 km W of Ahar, Iran",earthquake,,,,85,reviewed,teh,us
+2012-08-11T15:43:19.200Z,38.436,46.735,9.7,5,mb,126,31.9,,,us,usp000jq63,2014-11-07T01:48:33.155Z,"29 km W of Ahar, Iran",earthquake,,,,49,reviewed,teh,us
+2012-08-11T12:34:35.900Z,38.389,46.745,12,6.2,mww,522,19.9,,0.98,us,usp000jq5r,2022-05-03T16:56:39.289Z,"30 km WSW of Ahar, Iran",earthquake,,,,,reviewed,us,us
+2012-08-11T12:30:12.000Z,38.44,46.78,4,5,mb,61,69.9,,,us,usp000jq5q,2014-11-07T01:48:33.064Z,"25 km W of Ahar, Iran",earthquake,,,,2,reviewed,teh,us
+2012-08-11T12:23:18.190Z,38.329,46.826,11,6.4,mww,510,21.2,,1.23,us,usp000jq5p,2022-05-03T16:44:12.644Z,"26 km SW of Ahar, Iran",earthquake,,,,,reviewed,us,us
+2012-08-05T20:37:23.800Z,37.421,42.965,17.5,5,mb,126,44.4,,1.18,us,usp000jpxn,2022-05-03T15:45:34.724Z,"3 km NW of Gülyaz?, Turkey",earthquake,,6,,49,reviewed,us,us
+2012-07-24T06:50:06.020Z,31.705,50.961,10,5.2,mb,236,24.9,,1.02,us,usp000jpcx,2022-05-03T15:44:33.033Z,"42 km SW of Bor?jen, Iran",earthquake,,,,117,reviewed,us,us
+2012-07-22T09:26:02.990Z,37.546,36.384,7.6,5,mb,226,54.4,,,us,usp000jpab,2015-03-24T02:40:50.791Z,"4 km SE of And?r?n, Turkey",earthquake,,,,128,reviewed,isk,us
+2012-07-09T13:55:00.580Z,35.604,28.919,55.8,5.6,mww,468,41.5,,0.88,us,usp000jnt4,2022-05-03T15:43:44.522Z,"85 km SSW of Kalkan, Turkey",earthquake,,2.3,,,reviewed,us,us
+2012-07-01T22:01:25.900Z,34.481,59.927,28,5.1,mwb,188,24.8,,,us,usp000jnfq,2022-05-03T15:43:30.008Z,"82 km WSW of T?yb?d, Iran",earthquake,,,,,reviewed,teh,us
+2012-07-01T02:49:46.000Z,31.841,51.02,6.6,5,mb,260,26.7,,,us,usp000jner,2022-05-03T15:43:28.793Z,"28 km WSW of Bor?jen, Iran",earthquake,,,,84,reviewed,teh,us
+2012-06-25T13:05:28.000Z,36.439,28.941,26.4,5,mw,202,40.6,,,us,usp000jn7f,2022-05-03T15:43:00.602Z,"23 km SW of Ölüdeniz, Turkey",earthquake,,,,,reviewed,isk,csem
+2012-06-14T05:52:53.610Z,37.294,42.325,5.4,5.3,mb,338,35.7,,,us,usp000jmr8,2022-05-03T16:41:29.837Z,"1 km NNW of P?narönü, Turkey",earthquake,,,,244,reviewed,isk,us
+2012-06-10T12:44:16.590Z,36.42,28.88,35,6,mww,529,40.6,,,us,usp000jmkj,2022-05-03T15:42:27.624Z,"28 km SW of Ölüdeniz, Turkey",earthquake,,,,,reviewed,ath,us
+2012-05-22T00:00:32.770Z,42.645,22.968,10,5.6,mww,661,14,,0.87,us,usp000jkrw,2022-05-03T15:40:28.818Z,Serbia-Bulgaria-Macedonia border region,earthquake,,,,,reviewed,us,us
+2012-05-18T14:47:22.400Z,41.439,46.789,18.1,5.1,mb,87,64.8,,0.97,us,usp000jkjw,2021-10-20T17:40:02.371Z,"11 km WSW of Çinarl?, Azerbaijan",earthquake,,5.7,,38,reviewed,us,us
+2012-05-11T18:48:29.580Z,34.304,34.142,16.6,5.4,mb,351,40.6,,0.91,us,usp000jkam,2015-03-24T01:29:19.640Z,"76 km S of Ayia Napa, Cyprus",earthquake,,4.1,,201,reviewed,us,us
+2012-05-07T14:15:14.450Z,41.553,46.719,11.9,5.3,mww,510,17.4,,0.89,us,usp000jk4p,2022-05-03T15:39:42.952Z,"4 km WNW of Mamrux, Azerbaijan",earthquake,,3.3,,,reviewed,us,us
+2012-05-07T04:40:27.790Z,41.549,46.789,11,5.6,mww,438,20.1,,0.88,us,usp000jk44,2022-05-03T15:56:22.792Z,"1 km ENE of Mamrux, Azerbaijan",earthquake,,,,,reviewed,us,us
+2012-05-03T15:20:25.670Z,39.175,29.092,3.1,5.2,mwb,262,19.6,,,us,usp000jjyr,2022-05-03T17:03:17.322Z,"13 km NE of Simav, Turkey",earthquake,,,,,reviewed,isk,us
+2012-05-03T10:09:35.640Z,32.747,47.726,10,5.2,mwb,331,31.5,,1.13,us,usp000jjyd,2022-05-03T15:38:47.513Z,"39 km SE of ?bd?n?n, Iran",earthquake,,,,,reviewed,us,us
+2012-04-21T05:25:08.410Z,32.407,47.049,10,5,mb,182,49.4,,1.19,us,usp000jjba,2022-05-03T15:37:26.010Z,"34 km E of ‘Al? al Gharb?, Iraq",earthquake,,,,83,reviewed,us,us
+2012-04-20T03:05:41.780Z,32.453,46.99,10,5,mb,165,49.5,,1.15,us,usp000jj8y,2022-05-03T15:37:16.434Z,"28 km E of ‘Al? al Gharb?, Iraq",earthquake,,,,71,reviewed,us,us
+2012-04-20T01:21:07.540Z,32.511,47.023,10,5.1,mb,202,49,,1.18,us,usp000jj8r,2022-05-03T15:37:14.671Z,"30 km SW of Dehlor?n, Iran",earthquake,,,,88,reviewed,us,us
+2012-04-18T18:42:57.960Z,32.506,47.004,10,5.1,mb,203,38.1,,1.09,us,usp000jj6u,2022-05-03T15:37:28.349Z,"30 km E of ‘Al? al Gharb?, Iraq",earthquake,,,,110,reviewed,us,us
+2012-04-16T11:23:43.380Z,36.632,21.475,29,5.8,mww,434,45.4,,1.41,us,usp000jj2g,2022-05-03T16:58:02.032Z,"29 km SW of Methóni, Greece",earthquake,,,,,reviewed,us,us
+2012-03-26T10:35:32.640Z,39.171,42.33,5,5,mwr,294,28.3,,,us,usp000jgts,2022-05-03T15:34:36.936Z,"10 km NNE of Bulan?k, Turkey",earthquake,,,,,reviewed,isk,us
+2012-03-08T18:21:38.500Z,32.874,46.957,18,5.1,mb,191,51.9,,,us,usp000jfyn,2022-05-03T15:33:27.611Z,"35 km NW of Dehlor?n, Iran",earthquake,,,,109,reviewed,thr,us
+2012-03-04T03:31:08.400Z,40.134,24.059,2.5,5.2,mwr,317,35.3,,,us,usp000jfrz,2022-05-03T15:32:35.386Z,"8 km ENE of Sárti, Greece",earthquake,,,,,reviewed,the,us
+2012-02-27T18:48:55.300Z,31.428,56.778,10,5.2,mb,211,50.9,,,us,usp000jfgu,2022-05-03T15:32:21.725Z,"18 km N of R?var, Iran",earthquake,,,,98,reviewed,teh,us
+2012-02-14T01:34:38.700Z,40.13,24.09,24,5.2,mwr,394,11.5,,,us,usp000jewy,2022-05-03T16:57:09.486Z,"10 km ENE of Sárti, Greece",earthquake,,,,,reviewed,ath,us
+2012-01-27T01:33:24.000Z,36.044,25.064,5.2,5.3,mwc,249,22.3,,,us,usp000je0w,2022-05-03T15:26:57.790Z,"48 km SW of Emporeío, Greece",earthquake,,,,,reviewed,the,gcmt
+2012-01-26T04:24:58.300Z,36.06,25.07,29,5.2,mb,315,22.1,,,us,usp000jdzp,2022-05-03T15:26:52.110Z,"Dodecanese Islands, Greece",earthquake,,,,94,reviewed,ath,us
+2012-01-19T12:35:51.300Z,36.288,58.835,8.3,5.1,mww,290,40.8,,,us,usp000jdqd,2022-05-03T15:26:38.273Z,"9 km NNE of Neysh?b?r, Iran",earthquake,,,,,reviewed,teh,us
+2012-01-11T17:08:00.600Z,36.328,52.775,15.8,5.1,mb,158,32.1,,,us,usp000jdc1,2022-05-03T15:26:21.894Z,"26 km SSE of B?bol, Iran",earthquake,,,,76,reviewed,teh,us
+2011-11-30T00:47:21.760Z,38.474,43.454,4.3,5.4,mwc,180,24.9,,,us,usp000jbmn,2022-04-08T22:12:46.847Z,"6 km ESE of Van, Turkey",earthquake,,,,,reviewed,isk,gcmt
+2011-11-23T12:17:51.280Z,34.285,25.083,10,5.5,mwc,345,42.1,,1.03,us,usp000jba2,2022-04-08T22:12:29.744Z,"80 km S of Pýrgos, Greece",earthquake,,,,,reviewed,us,gcmt
+2011-11-21T01:56:41.800Z,32.2,59.92,14.2,5,mwc,124,30.7,,,us,usp000jb6f,2022-04-08T22:12:19.432Z,"98 km SE of B?rjand, Iran",earthquake,,,,,reviewed,thr,gcmt
+2011-11-14T22:08:15.410Z,38.658,43.17,10,5.2,mwc,155,38.2,,1.22,us,usp000javz,2022-04-08T22:22:28.829Z,"25 km NW of Van, Turkey",earthquake,,,,,reviewed,us,gcmt
+2011-11-09T19:23:33.240Z,38.429,43.229,5,5.6,mww,368,19.7,,,us,usp000jamz,2022-04-08T22:22:31.262Z,"2 km WNW of Edremit, Turkey",earthquake,,,,,reviewed,isk,us
+2011-11-08T22:05:51.020Z,38.718,43.191,10,5.2,mwb,439,19.9,,0.99,us,usp000jakt,2022-04-08T22:22:30.076Z,"29 km NW of Van, Turkey",earthquake,,,,,reviewed,us,us
+2011-10-29T22:24:21.900Z,38.89,43.56,5,5.1,mwc,134,25,,,us,usp000ja3h,2022-04-08T22:09:53.840Z,"23 km SE of Erci?, Turkey",earthquake,,,,,reviewed,isk,gcmt
+2011-10-27T08:04:22.420Z,37.256,43.86,10,5.1,mwc,177,52.3,,0.91,us,usp000j9z9,2022-04-08T22:22:25.459Z,"21 km E of Çukurca, Turkey",earthquake,,,,,reviewed,us,gcmt
+2011-10-25T14:55:08.240Z,38.811,43.623,14,5.6,mww,419,19.7,,0.91,us,usp000j9w5,2022-04-08T22:09:20.544Z,"33 km SE of Erci?, Turkey",earthquake,,,,,reviewed,us,us
+2011-10-24T15:28:06.790Z,38.674,43.198,10.6,5,mwc,113,38.1,,1.04,us,usp000j9ur,2022-04-08T22:22:02.786Z,"25 km NW of Van, Turkey",earthquake,,5.2,,,reviewed,us,gcmt
+2011-10-23T20:45:34.860Z,38.634,43.077,5,5.9,mww,408,19.6,,,us,usp000j9t8,2022-04-08T22:09:07.528Z,eastern Turkey,earthquake,,,,,reviewed,isk,us
+2011-10-23T18:10:45.160Z,38.71,43.338,5,5.1,mwc,144,34.6,,,us,usp000j9t0,2022-04-08T22:08:58.152Z,"24 km N of Van, Turkey",earthquake,,,,,reviewed,isk,gcmt
+2011-10-23T11:32:41.220Z,38.809,43.3,5,5.7,mb,512,14.1,,,us,usp000j9s2,2022-04-08T22:08:50.245Z,"24 km SSW of Erci?, Turkey",earthquake,,,,285,reviewed,isk,us
+2011-10-23T11:10:47.050Z,38.325,42.607,10,5,mb,41,74.2,,1.34,us,usp000j9rz,2014-11-07T01:46:09.378Z,"19 km NE of Hizan, Turkey",earthquake,,,,21,reviewed,us,us
+2011-10-23T11:00:29.140Z,38.603,43.101,10,5.2,mb,48,83.8,,1.15,us,usp000j9rx,2022-04-08T22:12:10.950Z,"24 km NW of Edremit, Turkey",earthquake,,,,14,reviewed,us,us
+2011-10-23T10:56:49.000Z,38.814,43.446,5,5.6,mb,324,21.3,,,us,usp000j9rv,2022-04-08T22:22:24.354Z,"24 km SSE of Erci?, Turkey",earthquake,,,,207,reviewed,isk,us
+2011-10-23T10:48:17.420Z,38.751,43.595,9,5.6,mb,127,75.4,,,us,usp000j9rs,2022-04-08T22:08:49.137Z,"33 km NNE of Van, Turkey",earthquake,,,,61,reviewed,isk,us
+2011-10-23T10:41:23.250Z,38.721,43.508,18,7.1,mww,693,19.7,,0.93,us,usp000j9rr,2022-04-08T22:08:47.620Z,"27 km NNE of Van, Turkey",earthquake,,,,,reviewed,us,us
+2011-09-27T12:08:22.900Z,34.52,23.78,28,5.3,mwc,289,41.4,,,us,usp000j8mm,2014-11-07T01:45:57.565Z,"44 km SW of Kastrí, Greece",earthquake,,,,,reviewed,ath,gcmt
+2011-09-22T03:22:36.070Z,39.785,38.842,5,5.5,mwb,455,20.7,,,us,usp000j8cv,2022-04-08T22:06:02.635Z,"13 km SSE of Refahiye, Turkey",earthquake,,,,,reviewed,isk,us
+2011-09-14T03:35:27.590Z,37.19,22.05,10,5,mb,233,43.2,,,us,usp000j812,2015-03-24T01:21:04.374Z,"3 km N of Arfará, Greece",earthquake,,,,86,reviewed,ath,us
+2011-09-13T16:19:31.890Z,34.409,23.722,41.2,5.2,mwc,224,51.8,,1.11,us,usp000j808,2014-11-07T01:45:53.374Z,"Crete, Greece",earthquake,,3.6,,,reviewed,us,gcmt
+2011-08-20T02:00:24.500Z,37.924,21.706,7.3,5.1,mwc,223,36.5,,,us,usp000j6pz,2022-04-08T21:59:39.636Z,"16 km SSE of Káto Mazaráki, Greece",earthquake,,,,,reviewed,the,gcmt
+2011-08-11T22:32:18.800Z,36.531,54.734,2.7,5,mwc,108,47.9,,,us,usp000j6b2,2022-04-08T21:58:41.653Z,"25 km WNW of Shahrud, Iran",earthquake,,,,,reviewed,teh,gcmt
+2011-08-07T14:35:34.460Z,38.438,21.826,8.6,5,mwr,280,32.1,,0.99,us,usp000j64x,2022-04-08T22:22:10.127Z,"5 km N of Náfpaktos, Greece",earthquake,,2.5,,,reviewed,us,us
+2011-07-26T04:04:10.700Z,36.52,56.89,6.4,5,mb,161,49.6,,,us,usp000j5gy,2022-04-08T21:55:50.723Z,"78 km WNW of Sabzevar, Iran",earthquake,,,,46,reviewed,thr,us
+2011-07-25T17:57:20.610Z,40.802,27.752,16.4,5.1,mwc,198,34.2,,,us,usp000j5g9,2022-04-08T22:22:01.435Z,"25 km SW of Marmara Ere?lisi, Turkey",earthquake,,,,,reviewed,isk,gcmt
+2011-07-19T07:13:12.200Z,37.21,19.92,9,5.1,mwc,300,36.3,,,us,usp000j553,2014-11-07T01:45:23.984Z,"98 km SW of Lithakiá, Greece",earthquake,,,,,reviewed,ath,gcmt
+2011-06-26T19:47:00.000Z,30.21,57.63,13,5.1,mwc,126,55.4,,,us,usp000j3t9,2022-04-08T21:52:34.924Z,"53 km E of Kerman, Iran",earthquake,,,,,reviewed,teh,gcmt
+2011-06-23T07:34:42.740Z,38.578,39.64,6.1,5.2,mwr,191,42.2,,,us,usp000j3ku,2022-07-19T18:31:29.008Z,"24 km SW of Kovanc?lar, Turkey",earthquake,,,,,reviewed,isk,us
+2011-05-19T20:39:03.330Z,34.377,23.723,26,5.2,mwc,146,74.3,,1.16,us,usp000j1us,2014-11-07T01:44:52.569Z,"60 km SSW of Kastrí, Greece",earthquake,,9.6,,,reviewed,us,gcmt
+2011-05-19T20:15:22.940Z,39.149,29.103,7,5.8,mww,507,19.9,,,us,usp000j1up,2022-07-19T15:37:34.514Z,"12 km ENE of Simav, Turkey",earthquake,,,,,reviewed,isk,us
+2011-05-08T06:50:24.300Z,36.704,27.238,11,5.1,mwr,253,32.1,,,us,usp000j16w,2022-07-19T14:34:33.556Z,"12 km SE of Kardámaina, Greece",earthquake,,,,,reviewed,the,us
+2011-04-01T13:29:10.690Z,35.662,26.56,59.9,6,mww,395,23.9,,,us,usp000hz2h,2022-07-19T10:57:23.397Z,"42 km NW of Fry, Greece",earthquake,,,,,reviewed,ath,us
+2011-03-05T11:24:43.740Z,30.019,51.156,10,5.3,mwc,204,47.7,,0.92,us,usp000hvcm,2022-04-08T21:36:22.247Z,"36 km WSW of N?r?b?d, Iran",earthquake,,,,,reviewed,us,gcmt
+2011-02-28T07:49:07.000Z,34.98,25.42,53,5.7,mwc,241,40.1,,,us,usp000hv5x,2022-07-19T06:33:28.316Z,"22 km W of Néa Anatolí, Greece",earthquake,,,,,reviewed,ath,gcmt
+2011-01-19T09:17:49.750Z,41.961,42.657,10,5.2,mwr,242,35.5,,0.89,us,usp000htbr,2022-07-19T02:44:27.734Z,"18 km SE of Vani, Georgia",earthquake,,,,,reviewed,us,us
+2011-01-08T00:24:27.700Z,30.18,51.706,38.6,5.1,mwc,195,36.6,,,us,usp000hsqs,2022-07-19T02:03:00.774Z,"19 km ENE of N?r?b?d, Iran",earthquake,,,,,reviewed,thr,gcmt
+2011-01-07T23:53:03.330Z,30.149,51.594,29.9,5,mwc,130,39.1,,1.2,us,usp000hsqq,2022-04-08T21:29:08.444Z,"7 km ENE of N?r?b?d, Iran",earthquake,,10.9,,,reviewed,us,gcmt
+2011-01-05T05:55:48.370Z,30.145,51.789,15.5,5.4,mwc,193,20.8,,1.16,us,usp000hskn,2022-07-19T01:58:32.778Z,"25 km E of N?r?b?d, Iran",earthquake,,12.2,,,reviewed,us,gcmt
+2010-12-18T06:05:41.500Z,37.28,20.22,24,5,mb,129,44.3,,,us,usp000hr32,2014-11-07T01:43:09.338Z,"72 km SW of Lithakiá, Greece",earthquake,,,,25,reviewed,ath,us
+2010-11-11T20:08:00.870Z,37.899,27.343,11.8,5,mwc,142,27.3,,,us,usp000hpe2,2016-11-10T02:35:59.466Z,"6 km SSW of Selçuk, Turkey",earthquake,,,,,reviewed,isk,gcmt
+2010-11-03T18:13:11.110Z,40.036,13.247,468.3,5.2,mwc,248,31.3,,0.75,us,usp000hnz9,2016-11-10T00:22:12.218Z,"85 km S of Ventotene, Italy",earthquake,,1.8,,,reviewed,us,gcmt
+2010-11-03T02:51:27.000Z,40.423,26.333,15.3,5.3,mwc,241,25.9,,,us,usp000hnya,2022-07-18T23:23:57.707Z,"26 km N of Eceabat, Turkey",earthquake,,,,,reviewed,isk,gcmt
+2010-11-03T00:56:55.400Z,43.76,20.73,0.9,5.5,mwc,380,16.7,,,us,usp000hny4,2022-07-18T23:22:20.268Z,"5 km NE of Kraljevo, Serbia",earthquake,,,,,reviewed,beo,gcmt
+2010-10-09T19:04:49.840Z,38.169,22.744,10.8,5.1,mb,191,22.4,,1.05,us,usp000hmwp,2014-11-07T01:42:41.156Z,"14 km NE of Xylókastro, Greece",earthquake,,2.4,,48,reviewed,us,us
+2010-10-03T15:20:57.810Z,34.927,26.541,10,5.3,mwc,233,50.9,,1.14,us,usp000hmj5,2022-07-18T21:24:01.040Z,"39 km SE of Palekastro, Greece",earthquake,,,,,reviewed,us,gcmt
+2010-08-27T19:23:49.500Z,35.49,54.47,7,5.8,mwc,301,37.2,,,us,usp000hjuq,2022-07-18T19:07:50.553Z,"76 km S of D?mgh?n, Iran",earthquake,,,,,reviewed,teh,gcmt
+2010-08-22T10:22:58.000Z,37.24,19.95,24,5.5,mwc,237,36.3,,,us,usp000hjm4,2022-07-18T18:58:01.428Z,"94 km SW of Lithakiá, Greece",earthquake,,,,,reviewed,ath,gcmt
+2010-08-11T17:26:19.700Z,37.799,57.017,14.8,5,mb,138,50.2,,,us,usp000hhyx,2022-05-02T22:08:16.656Z,"45 km NW of Bojn?rd, Iran",earthquake,,,,69,reviewed,thr,us
+2010-07-30T13:50:12.570Z,35.221,59.317,19,5.5,mwc,198,20.8,,1.11,us,usp000hh5v,2022-07-18T17:23:10.024Z,"10 km ESE of Torbat-e ?eydar?yeh, Iran",earthquake,,,,,reviewed,us,gcmt
+2010-07-16T18:53:10.450Z,39.34,23.992,9.1,5,mwc,222,17.8,,1.13,us,usp000hfc7,2022-07-18T16:28:04.146Z,"24 km NNE of Patitírion, Greece",earthquake,,3.4,,,reviewed,us,gcmt
+2010-07-16T08:11:01.900Z,36.81,26.91,165,5.1,mwc,225,46.1,,,us,usp000hfbp,2022-07-18T16:22:33.429Z,"8 km NNW of Kéfalos, Greece",earthquake,,,,,reviewed,ath,gcmt
+2010-04-24T15:01:12.600Z,34.45,26.01,34.5,5.4,mwc,306,42.2,,,us,usp000hbuw,2022-07-16T11:43:37.625Z,"66 km SSE of Ierápetra, Greece",earthquake,,,,,reviewed,ath,gcmt
+2010-03-24T14:11:31.000Z,38.821,40.138,4.5,5.1,mwc,161,41.8,,,us,usp000h9xv,2022-07-16T08:47:27.559Z,"17 km SSE of Karakoçan, Turkey",earthquake,,,,,reviewed,isk,gcmt
+2010-03-08T11:12:10.790Z,38.776,40.143,5,5.1,mwc,150,26.2,,,us,usp000h8y1,2022-07-16T05:46:04.944Z,"21 km ENE of Palu, Turkey",earthquake,,,,,reviewed,isk,gcmt
+2010-03-08T10:14:23.480Z,38.828,40.119,5,5.2,mb,136,26.1,,,us,usp000h8xy,2014-11-07T01:40:57.415Z,"15 km SSE of Karakoçan, Turkey",earthquake,,,,63,reviewed,isk,us
+2010-03-08T07:47:41.960Z,38.709,40.051,10,5.6,mwc,250,28.1,,1.08,us,usp000h8xh,2022-05-02T21:43:39.850Z,"11 km E of Palu, Turkey",earthquake,,,,,reviewed,us,gcmt
+2010-03-08T02:32:34.710Z,38.864,39.986,12,6.1,mwc,379,22,,0.76,us,usp000h8x1,2022-07-16T05:39:41.488Z,"10 km SSW of Karakoçan, Turkey",earthquake,,,,,reviewed,us,us
+2010-02-23T10:25:56.850Z,32.508,48.29,35,5.2,mwc,180,47.6,,1.02,us,usp000h7m1,2022-07-16T03:02:54.771Z,"24 km NW of Shahrak-e K?l?r?, Iran",earthquake,,,,,reviewed,us,gcmt
+2010-02-11T21:56:31.510Z,34,25.393,14,5.5,mwc,453,42.5,,1.02,us,usp000h76q,2016-11-10T02:24:05.712Z,"113 km S of Pýrgos, Greece",earthquake,,,,,reviewed,us,gcmt
+2010-01-22T00:50:32.720Z,38.45,21.963,1.4,5,mb,116,44.1,,1.36,us,usp000h6fh,2022-07-16T01:01:59.597Z,"13 km ENE of Náfpaktos, Greece",earthquake,,10.7,,47,reviewed,us,us
+2010-01-22T00:46:56.700Z,38.422,22.043,5,5.4,mwc,471,25.5,,0.99,us,usp000h6ff,2022-05-02T21:35:14.374Z,"14 km NNE of Kamárai, Greece",earthquake,,2.2,,,reviewed,us,gcmt
+2010-01-18T15:56:09.000Z,38.404,21.961,0.8,5.5,mwc,265,36.1,,,us,usp000h6a0,2022-07-16T00:34:48.181Z,"11 km E of Náfpaktos, Greece",earthquake,,,,,reviewed,the,gcmt
+2010-01-16T20:23:37.000Z,32.45,48.3,5,5,mb,173,58.7,,,us,usp000h678,2022-05-02T21:34:16.675Z,"19 km NW of Shahrak-e K?l?r?, Iran",earthquake,,,,76,reviewed,teh,us
+2010-01-01T02:34:56.050Z,40.726,51.925,46.1,5,mb,148,82.3,,0.88,us,usp000h5jt,2014-11-07T01:40:22.300Z,"117 km NW of Türkmenba?y, Turkmenistan",earthquake,,,,60,reviewed,us,us
+2009-12-29T11:08:54.720Z,32.567,15.064,10,5,mwc,139,46.5,,1.24,us,usp000h5f8,2022-05-02T21:32:42.883Z,"21 km N of Mi?r?tah, Libya",earthquake,,,,,reviewed,us,gcmt
+2009-12-22T06:06:23.430Z,35.72,31.511,63.5,5.3,mwc,302,41.6,,1.09,us,usp000h58s,2022-07-15T23:10:11.952Z,"94 km SW of Gazipa?a, Turkey",earthquake,,2.4,,,reviewed,us,gcmt
+2009-11-26T15:09:16.720Z,36.091,21.4,28.5,5,mwc,235,38.4,,1.17,us,usp000h4ey,2016-11-10T02:20:51.031Z,"85 km SSW of Methóni, Greece",earthquake,,6.4,,,reviewed,us,gcmt
+2009-11-11T09:51:06.540Z,37.505,20.358,10,5.3,mwc,219,36.2,,1.03,us,usp000h3ym,2022-07-15T20:51:05.525Z,"47 km WSW of Lithakiá, Greece",earthquake,,,,,reviewed,us,gcmt
+2009-11-03T05:25:08.130Z,37.504,20.491,10,5.8,mwc,281,36.3,,1.17,us,usp000h3pp,2022-07-15T20:30:23.266Z,"38 km SW of Lithakiá, Greece",earthquake,,,,,reviewed,us,gcmt
+2009-10-04T21:50:52.300Z,31.874,49.492,9.4,5.1,mb,224,47.5,,,us,usp000h2cv,2022-05-02T21:21:50.535Z,"19 km ESE of Masjed Soleym?n, Iran",earthquake,,,,95,reviewed,teh,us
+2009-09-07T22:41:37.360Z,42.66,43.443,15,6,mwc,309,32,,0.75,us,usp000h1ar,2022-07-15T17:26:51.428Z,"8 km N of Oni, Georgia",earthquake,,,,,reviewed,us,gcmt
+2009-09-06T21:49:42.170Z,41.483,20.388,3,5.5,mwc,372,21,,1.12,us,usp000h19n,2022-07-15T17:18:34.576Z,"12 km WSW of Debar, North Macedonia",earthquake,,,,,reviewed,us,us
+2009-08-21T13:39:58.840Z,41.898,19.123,22.8,5.1,mwc,272,38,,1.28,us,usp000h0qa,2022-07-15T16:16:55.832Z,"9 km WSW of Ulcinj, Montenegro",earthquake,,4.7,,,reviewed,us,gcmt
+2009-08-05T07:49:03.240Z,43.447,28.692,10,5,mwc,116,48.3,,1.15,us,usp000h003,2022-07-15T15:14:54.758Z,"16 km SE of Shabla, Bulgaria",earthquake,,,,,reviewed,us,gcmt
+2009-07-30T07:37:51.720Z,39.588,39.726,10,5,mwc,109,52.7,,1.23,us,usp000gztb,2022-07-15T14:49:03.603Z,"13 km S of Cimin, Turkey",earthquake,,,,,reviewed,us,gcmt
+2009-07-18T20:32:29.990Z,35.888,43.353,25.8,5.1,mwc,178,44.6,,0.8,us,usp000gze0,2022-07-15T14:16:49.493Z,"42 km S of Al-Hamdaniya, Iraq",earthquake,,8.7,,,reviewed,us,gcmt
+2009-07-01T09:30:10.410Z,34.164,25.471,19,6.4,mwc,396,20.5,,0.82,us,usp000gytt,2022-07-15T12:49:54.143Z,"95 km S of Néa Anatolí, Greece",earthquake,,,,,reviewed,us,us
+2009-06-20T08:28:19.000Z,37.68,26.86,12,5.1,mwc,175,35.1,,,us,usp000gydg,2022-05-02T20:42:12.377Z,"4 km SW of Chóra, Greece",earthquake,,,,,reviewed,ath,gcmt
+2009-06-19T14:04:59.030Z,35.358,28.453,28,5.8,mwc,366,41.7,,1.18,us,usp000gych,2022-07-15T12:05:24.519Z,"90 km SSE of Lárdos, Greece",earthquake,,,,,reviewed,us,us
+2009-06-18T04:26:14.700Z,35.377,28.413,39.5,5,mwc,204,41.6,,1.01,us,usp000gyaw,2016-11-10T02:13:31.964Z,"87 km SSE of Lárdos, Greece",earthquake,,3.7,,,reviewed,us,gcmt
+2009-06-17T04:29:12.000Z,36.047,36.02,10.4,5,mb,199,79.2,,,us,usp000gy9p,2014-11-07T01:39:10.098Z,"9 km SW of Büyükçat, Turkey",earthquake,,,,63,reviewed,isk,us
+2009-06-02T14:39:35.250Z,40.28,53.015,52.3,5,mwc,137,60.6,,0.83,us,usp000gxt6,2022-05-02T21:12:11.355Z,"29 km N of Türkmenba?y, Turkmenistan",earthquake,,,,,reviewed,us,gcmt
+2009-05-24T16:17:50.800Z,41.303,22.714,0.1,5.3,mwb,275,18,,,us,usp000gxg1,2022-07-15T10:38:18.043Z,"11 km WNW of Stathmós Mourión, Greece",earthquake,,,,,reviewed,the,us
+2009-04-25T17:18:48.640Z,45.654,26.606,100.7,5.2,mwb,355,13.9,,,us,usp000gwk1,2022-07-15T08:49:18.936Z,"9 km SW of Nereju Mic, Romania",earthquake,,,,,reviewed,buc,us
+2009-04-13T21:14:24.000Z,42.504,13.363,7.5,5,mwc,227,24.2,,,us,usp000gw3r,2022-07-15T07:52:19.995Z,"5 km ESE of Capitignano, Italy",earthquake,,,,,reviewed,rom,gcmt
+2009-04-09T19:38:17.360Z,42.513,13.331,2.6,5.2,mwc,265,19.6,,0.94,us,usp000gvz0,2022-07-15T07:42:25.284Z,"2 km ESE of Capitignano, Italy",earthquake,,2.1,,,reviewed,us,gcmt
+2009-04-09T00:52:59.000Z,42.484,13.343,15.4,5.4,mwc,277,18.9,,,us,usp000gvxz,2022-08-09T09:14:20.838Z,"5 km SE of Capitignano, Italy",earthquake,,,,,reviewed,rom,gcmt
+2009-04-07T17:47:37.000Z,42.275,13.464,15.1,5.5,mwc,376,27.3,,,us,usp000gvvw,2022-08-09T09:13:17.920Z,"1 km SW of San Panfilo d'Ocre, Italy",earthquake,,,,,reviewed,rom,us
+2009-04-06T23:15:37.000Z,42.451,13.364,8.6,5.1,mwc,315,11.6,,,us,usp000gvux,2022-07-15T07:18:32.197Z,"5 km ENE of Pizzoli, Italy",earthquake,,,,,reviewed,rom,gcmt
+2009-04-06T01:32:39.000Z,42.334,13.334,8.8,6.3,mwc,488,15.4,,,us,usp000gvtu,2022-08-09T06:03:16.131Z,"3 km SE of Sassa, Italy",earthquake,,,,,reviewed,rom,us
+2009-02-17T05:28:19.000Z,39.107,29.039,7.3,5.2,mwc,183,34,,,us,usp000gu3g,2022-07-15T01:53:06.727Z,"5 km ENE of Simav, Turkey",earthquake,,,,,reviewed,isk,gcmt
+2009-02-16T23:16:38.500Z,37.13,20.78,15,5.5,mwc,310,36.9,,,us,usp000gu33,2022-07-15T01:48:31.275Z,"65 km S of Lithakiá, Greece",earthquake,,,,,reviewed,ath,gcmt
+2009-01-13T06:12:42.900Z,35.66,26.39,42,5.3,mwc,186,30.4,,,us,usp000gshs,2022-07-15T03:25:09.922Z,"52 km NNE of Palekastro, Greece",earthquake,,,,,reviewed,ath,gcmt
+2008-12-28T22:58:59.000Z,40.39,25.78,35,5.2,mwc,353,14.4,,,us,usp000grr8,2022-07-14T23:07:15.368Z,"23 km NNW of Gökçeada, Turkey",earthquake,,,,,reviewed,ath,gcmt
+2008-12-17T21:57:44.830Z,39.206,15.444,257,5.3,mwc,712,28.7,,0.96,us,usp000gqu0,2022-07-14T22:17:08.935Z,"53 km WSW of San Lucido, Italy",earthquake,,,,,reviewed,us,us
+2008-12-13T08:27:19.200Z,38.72,22.57,24,5.2,mwc,216,36.1,,,us,usp000gqgq,2022-07-14T22:07:03.638Z,"9 km NNW of Amfíkleia, Greece",earthquake,,,,,reviewed,ath,gcmt
+2008-12-01T10:18:40.100Z,35.299,46.544,27.6,5,mb,76,89.4,,,us,usp000gpr9,2014-11-07T01:37:51.204Z,"33 km NNE of P?veh, Iran",earthquake,,,,32,reviewed,teh,us
+2008-11-12T14:03:18.310Z,38.841,35.524,10,5.1,mwc,90,57.1,,1.28,us,usp000gnhr,2022-05-02T21:05:57.372Z,"12 km NNE of Kayseri, Turkey",earthquake,,0,,,reviewed,us,gcmt
+2008-10-14T02:06:34.700Z,38.85,23.62,24,5.2,mwc,296,44.7,,,us,usp000gk76,2022-05-02T21:04:50.375Z,"13 km ENE of Mantoúdi, Greece",earthquake,,,,,reviewed,ath,gcmt
+2008-10-11T09:22:01.210Z,43.337,46.192,10,5.3,mwc,279,60.1,,1.04,us,usp000gjy7,2016-11-10T02:02:38.798Z,"6 km ESE of Gudermes, Russia",earthquake,,,,,reviewed,us,gcmt
+2008-10-11T09:06:10.770Z,43.372,46.254,16,5.8,mwc,472,34.2,,1.05,us,usp000gjy6,2022-07-14T20:44:21.876Z,"10 km WNW of Engel’-Yurt, Russia",earthquake,,,,,reviewed,us,gcmt
+2008-09-03T22:43:13.000Z,32.3,47.2,8,5.1,mwc,372,58.6,,,us,usp000ggbq,2020-04-16T17:05:40.605Z,"44 km S of Dehlor?n, Iran",earthquake,,,,,reviewed,teh,gcmt
+2008-09-03T02:22:47.000Z,37.507,38.503,5.7,5,mwc,204,89.7,,,us,usp000gg9s,2022-05-02T19:45:14.223Z,"8 km SSE of Samsat, Turkey",earthquake,,,,,reviewed,isk,gcmt
+2008-09-02T20:00:50.820Z,38.724,45.794,3,5,mwc,190,28,,1.22,us,usp000gg8r,2016-11-10T02:01:10.193Z,"20 km SSW of Deste, Azerbaijan",earthquake,,5.6,,,reviewed,us,gcmt
+2008-08-27T21:52:38.110Z,32.308,47.35,10,5.8,mwc,449,35.6,,1.16,us,usp000gfre,2022-07-13T03:55:57.752Z,"43 km S of Dehlor?n, Iran",earthquake,,,,,reviewed,us,gcmt
+2008-08-04T19:38:25.300Z,34.098,26.576,30.5,5.3,mwc,545,42.9,,1.3,us,usp000gdun,2016-11-10T01:59:38.426Z,"125 km SSE of Palekastro, Greece",earthquake,,,,,reviewed,us,gcmt
+2008-08-03T00:39:16.860Z,39.608,23.849,10,5.3,mwc,335,18.3,,1.11,us,usp000gdq3,2022-05-02T21:01:44.376Z,"46 km SSE of Pefkochóri, Greece",earthquake,,,,,reviewed,us,us
+2008-07-30T05:02:56.000Z,38.02,20.12,9,5,mwc,318,43.3,,,us,usp000gder,2022-05-02T21:01:39.578Z,"34 km SW of Lixoúri, Greece",earthquake,,,,,reviewed,ath,gcmt
+2008-07-15T03:26:34.700Z,35.8,27.86,52,6.4,mwc,774,18.7,,1.35,us,usp000gc72,2022-07-13T04:29:09.768Z,"35 km SSW of Lárdos, Greece",earthquake,,,,,reviewed,us,us
+2008-07-03T23:10:02.000Z,35.5,58.8,10,5.2,mwc,242,49.3,,,us,usp000gb95,2020-09-21T15:37:59.376Z,"42 km NE of K?shmar, Iran",earthquake,,,,,reviewed,teh,gcmt
+2008-06-21T11:36:23.900Z,36.06,21.82,5,5.6,mwc,592,40.9,,,us,usp000ga7w,2022-05-02T21:00:17.551Z,"82 km S of Koróni, Greece",earthquake,,,,,reviewed,ath,us
+2008-06-21T05:57:16.200Z,36.1,21.93,17,5.2,mwc,374,40.9,,,us,usp000ga7g,2016-11-10T01:57:41.713Z,"77 km S of Koróni, Greece",earthquake,,,,,reviewed,ath,gcmt
+2008-06-18T01:58:42.900Z,37.67,22.78,83,5.1,mwc,643,37.3,,,us,usp000g9y8,2022-07-13T04:47:10.222Z,"4 km NNW of Ayía Triás, Greece",earthquake,,,,,reviewed,ath,gcmt
+2008-06-12T00:20:45.600Z,35.11,26.19,29,5.1,mwc,522,41.4,,,us,usp000g99e,2022-05-02T21:00:06.704Z,"11 km SSW of Palekastro, Greece",earthquake,,,,,reviewed,ath,gcmt
+2008-06-08T12:25:29.710Z,37.963,21.525,16,6.4,mwc,706,25.7,,1.49,us,usp000g8vs,2022-07-13T18:45:03.570Z,"15 km ESE of Várda, Greece",earthquake,,,,,reviewed,us,gcmt
+2008-05-10T20:53:04.200Z,36.3,22.24,57,5.4,mwc,442,38.6,,,us,usp000g61d,2022-07-13T19:04:17.656Z,"58 km SSW of Gýtheio, Greece",earthquake,,,,,reviewed,ath,gcmt
+2008-04-25T04:48:54.000Z,37.819,29.256,5,5,mwc,308,16.1,,,us,usp000g4sw,2022-05-02T20:44:31.070Z,"6 km N of Honaz, Turkey",earthquake,,,,,reviewed,isk,gcmt
+2008-03-28T00:16:19.900Z,34.758,25.345,45,5.6,mwb,560,41.6,,1.19,us,usp000g2h6,2022-07-13T20:35:37.621Z,"32 km SSE of Pýrgos, Greece",earthquake,,,,,reviewed,us,us
+2008-03-23T20:11:11.920Z,36.145,21.856,35,5,mwc,267,66.3,,1.42,us,usp000g25j,2016-11-10T01:53:26.820Z,"72 km S of Koróni, Greece",earthquake,,,,,reviewed,us,gcmt
+2008-03-14T07:10:21.600Z,36.01,21.76,5,5.1,mwc,266,43.6,,,us,usp000g1f6,2016-11-10T01:53:04.481Z,"88 km SSW of Koróni, Greece",earthquake,,,,,reviewed,ath,gcmt
+2008-03-09T03:51:07.000Z,33.3,59.2,4,5,mwc,210,45.3,,,us,usp000g10w,2016-11-10T01:52:53.329Z,"47 km S of Q?’en, Iran",earthquake,,,,,reviewed,teh,gcmt
+2008-02-26T16:10:40.000Z,36.09,21.886,37.7,5,mwc,251,46.9,,1.19,us,usp000g016,2016-11-10T01:52:20.737Z,"78 km S of Koróni, Greece",earthquake,,3.6,,,reviewed,us,gcmt
+2008-02-26T10:46:07.330Z,35.907,21.866,5,5.4,mwc,219,55.1,,1.34,us,usp000g00b,2022-07-13T21:22:31.750Z,"98 km S of Koróni, Greece",earthquake,,,,,reviewed,us,gcmt
+2008-02-20T18:27:06.000Z,36.288,21.775,9.9,6.2,mwc,568,42.3,,1.29,us,usp000fzcj,2022-07-13T21:39:30.113Z,"58 km SSW of Koróni, Greece",earthquake,,5.3,,,reviewed,us,gcmt
+2008-02-19T23:15:40.000Z,36.19,21.77,22,5.3,mwc,397,46.7,,,us,usp000fz9c,2022-07-13T21:47:50.127Z,"69 km SSW of Koróni, Greece",earthquake,,,,,reviewed,ath,gcmt
+2008-02-15T10:36:19.090Z,33.327,35.305,10,5.1,mwc,253,43.5,,1.11,us,usp000fyyz,2022-07-13T22:01:01.945Z,"11 km ENE of Tyre, Lebanon",earthquake,,,,,reviewed,us,gcmt
+2008-02-14T12:08:55.790Z,36.345,21.863,28,6.5,mwc,650,30.7,,1.19,us,usp000fywh,2022-07-13T22:04:26.662Z,"50 km S of Koróni, Greece",earthquake,,,,,reviewed,us,gcmt
+2008-02-14T10:09:22.720Z,36.501,21.67,29,6.9,mwc,645,30.6,,1.31,us,usp000fyw4,2022-07-13T22:06:34.492Z,"35 km S of Methóni, Greece",earthquake,,,,,reviewed,us,gcmt
+2008-01-06T05:14:20.180Z,37.216,22.693,75,6.2,mwb,640,23.8,,1.22,us,usp000fw2w,2022-07-13T23:09:30.649Z,"15 km WNW of Leonídio, Greece",earthquake,,,,,reviewed,us,us
+2007-12-26T23:47:10.770Z,39.446,33.162,8.3,5.6,mwc,334,22.7,,1.08,us,usp000fvaw,2022-07-13T23:35:38.699Z,"24 km SW of Karakeçili, Turkey",earthquake,,3.8,,,reviewed,us,gcmt
+2007-12-20T09:48:29.950Z,39.417,33.212,10,5.7,mwc,302,50,,1.03,us,usp000fuw2,2022-07-13T23:52:17.511Z,"24 km SW of Karakeçili, Turkey",earthquake,,,,,reviewed,us,gcmt
+2007-11-16T09:08:23.000Z,37.021,29.257,5.3,5.1,mwc,128,45,,,us,usp000fspn,2022-07-14T01:12:06.217Z,"25 km W of Alt?nyayla, Turkey",earthquake,,,,,reviewed,isk,gcmt
+2007-11-09T01:43:04.200Z,38.733,25.724,9,5.2,mwc,378,25.8,,1.03,us,usp000fs7f,2022-07-14T01:27:01.357Z,"25 km NNE of Psará, Greece",earthquake,,5.8,,,reviewed,us,gcmt
+2007-10-29T09:23:14.000Z,37.033,29.233,5,5.3,mwc,414,44,,,us,usp000frhj,2022-07-14T01:45:26.621Z,"27 km WSW of Gölhisar, Turkey",earthquake,,,,,reviewed,isk,gcmt
+2007-10-27T05:29:39.000Z,37.72,21.3,16,5.1,mwc,417,36.5,,,us,usp000frbw,2022-07-14T01:47:08.455Z,"6 km SSW of Kardamás, Greece",earthquake,,,,,reviewed,ath,gcmt
+2007-09-23T00:54:29.600Z,35.27,27.12,24,5.3,mwc,399,41.5,,,us,usp000fnxd,2022-05-02T20:36:06.091Z,"24 km SE of Fry, Greece",earthquake,,,,,reviewed,ath,gcmt
+2007-08-31T20:52:43.430Z,36.655,26.272,25.1,5.2,mwc,328,31,,1.06,us,usp000fm3f,2022-07-14T03:34:00.383Z,"13 km NNW of Astypálaia, Greece",earthquake,,3.4,,,reviewed,us,gcmt
+2007-08-25T22:05:49.600Z,39.282,41.124,10,5.3,mwc,335,60.1,,1,us,usp000fkpq,2022-05-02T20:42:15.599Z,"10 km E of Karl?ova, Turkey",earthquake,,,,,reviewed,us,gcmt
+2007-07-11T06:51:14.320Z,38.751,48.598,25.6,5.2,mwc,176,21.9,,1.24,us,usp000ffyv,2022-05-02T20:21:36.298Z,"14 km W of Haftoni, Azerbaijan",earthquake,,,,,reviewed,us,gcmt
+2007-07-04T23:55:32.000Z,38.8,15.2,279,5.2,mwc,558,17,,,us,usp000ffgq,2016-11-10T01:41:50.381Z,"39 km NE of Santa Marina Salina, Italy",earthquake,,,,,reviewed,rom,gcmt
+2007-07-04T06:11:07.000Z,32.08,55.9,12,5,mwc,171,48.8,,,us,usp000fff0,2022-05-02T20:38:37.088Z,"70 km NE of B?fq, Iran",earthquake,,,,,reviewed,teh,gcmt
+2007-06-29T18:09:11.220Z,39.268,20.263,10,5.4,mwc,600,34.4,,1.28,us,usp000ff3j,2022-07-14T05:59:10.190Z,"10 km NE of Gáïos, Greece",earthquake,,,,,reviewed,us,gcmt
+2007-06-18T14:29:48.290Z,34.437,50.833,5,5.5,mwb,383,38.7,,1.25,us,usp000fe9m,2022-07-14T06:04:18.810Z,"22 km S of Qom, Iran",earthquake,,,,,reviewed,us,us
+2007-05-21T16:39:08.670Z,35.117,27.808,10,5,mwc,283,51.1,,1.43,us,usp000fcey,2016-11-10T01:40:20.355Z,"Dodecanese Islands, Greece",earthquake,,,,,reviewed,us,gcmt
+2007-04-10T22:00:34.240Z,38.005,30.923,5.8,5.1,mwc,322,16.6,,,us,usp000f9cr,2022-05-02T20:10:14.325Z,"15 km SSW of Gelendost, Turkey",earthquake,,,,,reviewed,isk,gcmt
+2007-04-10T10:41:00.240Z,38.551,21.642,0.1,5.2,mwc,443,24.7,,,us,usp000f9af,2022-05-02T20:10:08.031Z,"3 km SW of Thérmo, Greece",earthquake,,,,,reviewed,the,gcmt
+2007-04-10T07:15:41.590Z,38.529,21.542,6.3,5.1,mwc,156,33,,1.24,us,usp000f99d,2022-05-02T20:10:02.908Z,"0 km E of Gavaloú, Greece",earthquake,,4.9,,,reviewed,us,gcmt
+2007-04-10T03:17:56.350Z,38.551,21.636,2.7,5,mwc,430,25.2,,,us,usp000f97w,2022-05-02T20:10:01.368Z,"3 km SW of Thérmo, Greece",earthquake,,,,,reviewed,the,gcmt
+2007-03-25T13:57:58.200Z,38.34,20.42,15,5.7,mwb,514,35.4,,,us,usp000f7cx,2022-07-14T07:08:19.543Z,"15 km N of Lixoúri, Greece",earthquake,,,,,reviewed,ath,us
+2007-02-21T11:05:28.630Z,38.318,39.275,6,5.7,mwb,450,62,,1.15,us,usp000f5an,2022-07-14T07:43:34.056Z,"12 km N of Çüngü?, Turkey",earthquake,,,,,reviewed,us,us
+2007-02-09T02:22:55.000Z,38.39,39.043,2.6,5.5,mwc,347,64.2,,,us,usp000f4hn,2022-05-02T19:54:28.711Z,"9 km N of Do?anyol, Turkey",earthquake,,,,,reviewed,isk,gcmt
+2007-02-03T13:43:23.080Z,35.806,22.432,59.1,5.4,mwc,484,43.2,,1.16,us,usp000f473,2022-07-14T08:02:31.721Z,"63 km SW of Kýthira, Greece",earthquake,,2.5,,,reviewed,us,gcmt
+2007-01-21T07:38:57.000Z,39.592,42.863,3.1,5.2,mwc,262,21.7,,,us,usp000f343,2022-05-02T19:34:24.996Z,"10 km W of Hamur, Turkey",earthquake,,,,,reviewed,isk,gcmt
+2006-12-21T18:30:52.900Z,39.32,23.6,23,5.1,mwc,283,20.6,,,us,usp000f0qw,2022-05-02T18:33:48.689Z,"19 km NNE of Skiáthos, Greece",earthquake,,,,,reviewed,ath,gcmt
+2006-11-05T17:15:00.320Z,39.747,13.748,429.5,5,mb,410,38.9,,0.98,us,usp000ewpg,2014-11-07T01:30:45.594Z,"97 km SSW of Anacapri, Italy",earthquake,,1.5,,133,reviewed,us,us
+2006-10-26T14:28:37.310Z,38.649,15.39,212,5.8,mwc,675,15.1,,1.05,us,usp000ew2z,2022-07-14T09:09:03.642Z,"40 km W of San Nicolò, Italy",earthquake,,,,,reviewed,us,gcmt
+2006-10-24T14:00:21.670Z,40.424,29.107,9.3,5,mwc,227,29.8,,1.15,us,usp000evxq,2022-07-14T09:12:26.819Z,"4 km W of Gemlik, Turkey",earthquake,,,,,reviewed,us,gcmt
+2006-10-19T09:34:51.000Z,42.3,19.8,6,5,mb,259,33.5,,,us,usp000evh3,2014-11-07T01:30:35.885Z,"29 km S of Gusinje, Montenegro",earthquake,,,,23,reviewed,pdg,us
+2006-10-12T17:08:20.370Z,39.804,54.734,42.8,5.3,mwc,417,42.6,,0.92,us,usp000ev13,2022-07-14T09:31:03.031Z,"45 km NE of Balkanabat, Turkmenistan",earthquake,,,,,reviewed,us,gcmt
+2006-08-22T09:23:21.200Z,35.24,27.12,31,5.1,mwc,365,52.1,,,us,usp000ergj,2022-05-02T18:26:40.207Z,"26 km SE of Fry, Greece",earthquake,,,,,reviewed,ath,hrv
+2006-08-13T10:35:12.700Z,34.42,26.566,32.5,5.3,mwc,490,42.3,,1.32,us,usp000eqv5,2016-11-10T01:26:56.638Z,"90 km SSE of Palekastro, Greece",earthquake,,,,,reviewed,us,hrv
+2006-07-02T19:39:39.000Z,39.274,40.96,3,5,mwc,209,71.3,,,us,usp000emsw,2022-05-02T18:22:46.890Z,"4 km WSW of Karl?ova, Turkey",earthquake,,,,,reviewed,isk,hrv
+2006-06-21T15:54:44.600Z,39.007,20.595,10,5,mwc,279,42.6,,1.23,us,usp000ekyf,2022-05-02T18:22:19.878Z,"14 km WNW of Préveza, Greece",earthquake,,,,,reviewed,us,hrv
+2006-05-25T23:14:36.900Z,36.87,20.34,35,5.2,mwc,333,40.4,,,us,usp000ehyt,2016-11-10T01:22:50.486Z,"103 km SSW of Lithakiá, Greece",earthquake,,,,,reviewed,ath,hrv
+2006-05-07T06:20:53.700Z,30.79,56.7,14.1,5,mwc,148,56.2,,,us,usp000egfm,2020-09-18T21:00:42.577Z,"13 km E of Zarand, Iran",earthquake,,,,,reviewed,thr,hrv
+2006-04-19T15:16:24.600Z,37.66,20.93,19,5.4,mwc,399,47.7,,,us,usp000eexa,2022-05-02T15:29:38.747Z,"10 km SE of Lithakiá, Greece",earthquake,,,,,reviewed,ath,hrv
+2006-04-12T16:52:01.200Z,37.61,20.95,19,5.7,mwc,549,39.8,,,us,usp000eeah,2022-07-14T11:52:12.045Z,"16 km SE of Lithakiá, Greece",earthquake,,,,,reviewed,ath,hrv
+2006-04-11T17:29:28.400Z,37.68,20.91,18,5.5,mwc,426,39.7,,,us,usp000ee7d,2022-07-14T11:53:54.967Z,"8 km ESE of Lithakiá, Greece",earthquake,,,,,reviewed,ath,hrv
+2006-04-11T00:02:41.500Z,37.64,20.92,18,5.5,mwc,550,39.7,,,us,usp000ee4t,2022-07-14T11:55:42.649Z,"11 km SE of Lithakiá, Greece",earthquake,,,,,reviewed,ath,hrv
+2006-04-09T23:27:19.810Z,35.168,27.244,32.6,5.3,mwc,494,42.2,,1.34,us,usp000ee23,2022-05-02T15:28:54.011Z,"37 km S of Karpathos, Greece",earthquake,,,,,reviewed,us,hrv
+2006-04-04T22:05:05.080Z,37.64,20.962,16.8,5.5,mwc,464,39.7,,1.35,us,usp000edpz,2022-07-14T12:00:45.707Z,"14 km SE of Lithakiá, Greece",earthquake,,5.7,,,reviewed,us,hrv
+2006-04-03T00:49:42.800Z,37.59,20.95,20,5,mwc,397,39.8,,,us,usp000edjr,2022-05-02T18:14:19.341Z,"17 km SE of Lithakiá, Greece",earthquake,,,,,reviewed,ath,hrv
+2006-03-31T11:54:02.280Z,33.723,48.668,10,5.1,mwc,174,57.5,,1.2,us,usp000edba,2022-05-02T15:28:19.557Z,"20 km SSW of Bor?jerd, Iran",earthquake,,,,,reviewed,us,hrv
+2006-03-31T01:17:00.960Z,33.5,48.78,7,6.1,mwc,586,28.6,,1.06,us,usp000edad,2022-07-14T12:04:18.568Z,"18 km SW of Azn?, Iran",earthquake,,,,,reviewed,us,hrv
+2006-03-30T19:36:17.260Z,33.56,48.751,10,5.1,mwc,387,51.5,,1.13,us,usp000ed9r,2022-05-02T15:28:12.226Z,"17 km WSW of Azn?, Iran",earthquake,,,,,reviewed,us,hrv
+2006-03-29T22:05:15.190Z,35.252,35.427,27.3,5,mwc,254,70.9,,1.23,us,usp000ed83,2022-05-02T15:28:04.873Z,"45 km SW of Latakia, Syria",earthquake,,,,,reviewed,us,hrv
+2006-02-06T04:08:03.070Z,42.653,43.525,17,5.3,mwc,320,40.1,,1.04,us,usp000e9kv,2022-05-02T18:12:14.287Z,"10 km NE of Oni, Georgia",earthquake,,8.3,,,reviewed,us,hrv
+2006-01-08T11:34:55.640Z,36.311,23.212,66,6.7,mwb,769,19.7,,1.34,us,usp000e7u3,2022-07-14T12:48:53.972Z,"26 km NE of Kýthira, Greece",earthquake,,,,,reviewed,us,us
+2005-12-26T23:15:50.000Z,32.1,49.2,18,5,mwc,346,85,,,us,usp000e6zt,2022-05-02T18:10:47.219Z,western Iran,earthquake,,,,,reviewed,thr,hrv
+2005-12-10T00:09:50.230Z,39.394,40.946,10,5.4,mwc,293,73.7,,0.84,us,usp000e5w2,2022-05-02T18:08:42.528Z,"12 km NNW of Karl?ova, Turkey",earthquake,,,,,reviewed,us,hrv
+2005-11-26T15:56:55.000Z,38.26,38.814,8.5,5.1,mwc,330,56.3,,,us,usp000e4yn,2022-05-02T18:07:20.852Z,"19 km WSW of Do?anyol, Turkey",earthquake,,,,,reviewed,isk,hrv
+2005-11-25T09:30:56.900Z,35.02,23.32,32,5.2,mwc,450,51.4,,,us,usp000e4vn,2022-05-02T18:07:18.507Z,"40 km SW of Palaióchora, Greece",earthquake,,,,,reviewed,ath,hrv
+2005-10-20T23:32:23.190Z,31.693,50.485,43.6,5,mwc,300,50.6,,0.91,us,usp000e2c4,2022-05-02T18:05:05.804Z,"62 km S of F?rs?n, Iran",earthquake,,3.4,,,reviewed,us,hrv
+2005-10-20T21:40:04.090Z,38.152,26.751,10,5.9,mwb,494,19,,0.93,us,usp000e2bq,2022-07-14T13:53:52.706Z,"9 km WSW of Seferihisar, Turkey",earthquake,,,,,reviewed,us,us
+2005-10-18T15:36:28.410Z,37.58,21.154,20,5,mwc,214,123.7,,1.2,us,usp000e25b,2022-05-02T18:04:36.118Z,"26 km SW of Kardamás, Greece",earthquake,,0,,,reviewed,us,hrv
+2005-10-18T15:26:00.260Z,37.622,20.918,14.3,5.7,mwc,521,39.8,,1.13,us,usp000e25a,2022-07-14T14:01:06.966Z,"13 km SE of Lithakiá, Greece",earthquake,,,,,reviewed,us,hrv
+2005-10-17T09:55:30.000Z,38.143,26.615,20.7,5.2,mwc,287,21.1,,,us,usp000e20f,2022-05-02T18:04:25.964Z,"20 km WSW of Seferihisar, Turkey",earthquake,,,,,reviewed,isk,hrv
+2005-10-17T09:46:53.900Z,38.2,26.5,10.4,5.8,mwb,558,15.6,,,us,usp000e20e,2022-07-14T14:06:31.191Z,"14 km SE of Alaçat?, Turkey",earthquake,,,,,reviewed,isk,us
+2005-10-17T05:45:16.000Z,38.131,26.505,8.1,5.5,mwc,439,17.1,,,us,usp000e1zy,2022-07-14T14:08:15.037Z,"20 km SE of Alaçat?, Turkey",earthquake,,,,,reviewed,isk,hrv
+2005-09-27T00:25:35.620Z,43.155,18.203,19.4,5.1,mwc,373,14.4,,1.13,us,usp000e0ba,2022-07-14T14:38:43.634Z,"13 km SSE of Nevesinje, Bosnia and Herzegovina",earthquake,,,,,reviewed,us,hrv
+2005-09-26T18:57:04.000Z,37.3,47.8,14,5.2,mwc,340,31.3,,,us,usp000e0au,2022-05-02T18:01:08.155Z,"69 km ESE of Hashtr?d, Iran",earthquake,,,,,reviewed,thr,hrv
+2005-09-24T19:28:05.380Z,39.486,52.035,42.6,5.2,mwc,319,41.2,,0.92,us,usp000e04n,2022-05-02T17:59:56.457Z,"98 km SW of Türkmenba?y, Turkmenistan",earthquake,,4.8,,,reviewed,us,hrv
+2005-09-02T07:42:25.640Z,34.013,25.878,15.1,5.1,mwc,287,60.1,,1.2,us,usp000dyka,2016-11-10T01:11:05.820Z,"111 km S of Ierápetra, Greece",earthquake,,8.4,,,reviewed,us,hrv
+2005-08-04T10:45:30.420Z,34.887,26.497,9,5,mwc,280,54.2,,1.07,us,usp000dwng,2022-05-02T17:23:44.715Z,"40 km SSE of Palekastro, Greece",earthquake,,4.9,,,reviewed,us,hrv
+2005-07-30T21:45:00.000Z,39.437,33.089,5,5.2,mwc,383,22.9,,,us,usp000dwaw,2022-05-02T17:16:20.178Z,"30 km SW of Karakeçili, Turkey",earthquake,,,,,reviewed,isk,hrv
+2005-07-26T03:32:19.000Z,40.017,12.694,514.2,5,mb,354,28.8,,0.89,us,usp000dvxv,2014-11-07T01:26:33.622Z,"100 km SSW of Ponza, Italy",earthquake,,1.8,,67,reviewed,us,us
+2005-07-10T13:10:12.160Z,42.389,19.812,4.4,5.2,mwc,443,32.3,,1.08,us,usp000dux3,2022-07-14T15:33:07.506Z,"19 km S of Gusinje, Montenegro",earthquake,,2.6,,,reviewed,us,hrv
+2005-06-18T15:16:42.410Z,45.714,26.695,138.7,5,mwc,393,24.5,,1.02,us,usp000dtc5,2022-07-14T15:49:08.274Z,"0 km N of Nereju Mic, Romania",earthquake,,,,,reviewed,us,hrv
+2005-06-06T07:41:28.700Z,39.22,41.08,10,5.6,mwc,290,60.2,,,us,usp000dsbj,2022-05-02T16:45:46.299Z,"10 km SE of Karl?ova, Turkey",earthquake,,,,,reviewed,csem,hrv
+2005-05-14T23:46:50.530Z,35.687,31.582,69.2,5.1,mwc,422,48.1,,1.01,us,usp000dqua,2016-11-10T01:06:10.784Z,"92 km SW of Gazipa?a, Turkey",earthquake,,,,,reviewed,us,hrv
+2005-05-14T18:04:55.060Z,30.687,56.862,10,5.2,mwc,386,23.1,,1.01,us,usp000dqtq,2022-05-02T17:20:16.808Z,"31 km ESE of Zarand, Iran",earthquake,,,,,reviewed,us,hrv
+2005-05-14T01:53:20.660Z,45.684,26.437,148.9,5.2,mwc,628,11.6,,,us,usp000dqrj,2022-07-14T16:11:54.355Z,"16 km SE of Comand?u, Romania",earthquake,,,,,reviewed,buc,hrv
+2005-05-01T18:58:42.530Z,30.704,56.965,30.6,5.1,mwc,305,59.2,,1.08,us,usp000dpq7,2022-05-02T17:18:37.266Z,"40 km ESE of Zarand, Iran",earthquake,,8.3,,,reviewed,us,hrv
+2005-03-23T21:44:53.020Z,39.431,40.925,10,5.7,mwb,465,56.6,,1.13,us,usp000djx3,2022-05-02T17:50:58.780Z,"17 km NNW of Karl?ova, Turkey",earthquake,,,,,reviewed,us,us
+2005-03-14T01:55:55.600Z,39.354,40.89,5,5.8,mwc,578,24.1,,,us,usp000dj5f,2022-05-02T17:50:09.867Z,"12 km NW of Karl?ova, Turkey",earthquake,,,,,reviewed,isk,hrv
+2005-03-12T07:36:12.180Z,39.44,40.978,11.1,5.6,mwb,458,50.2,,1.13,us,usp000dj1q,2022-07-14T17:27:18.440Z,"16 km N of Karl?ova, Turkey",earthquake,,5.5,,,reviewed,us,us
+2005-02-22T02:25:22.920Z,30.754,56.816,14,6.4,mwc,652,27.7,,1.31,us,usp000dgpx,2022-07-14T17:58:16.794Z,"24 km ESE of Zarand, Iran",earthquake,,,,,reviewed,us,hrv
+2005-01-31T01:05:33.560Z,37.535,20.155,31.9,5.7,mwb,436,39.8,,1.06,us,usp000df8p,2022-05-02T17:47:16.622Z,"62 km WSW of Katastárion, Greece",earthquake,,4.3,,,reviewed,us,us
+2005-01-30T16:23:48.430Z,35.806,29.63,10,5.3,mwc,361,26.3,,1.3,us,usp000df83,2022-07-14T18:21:08.952Z,"43 km S of Ka?, Turkey",earthquake,,,,,reviewed,us,hrv
+2005-01-25T16:44:16.130Z,37.622,43.703,41.2,5.9,mwc,333,57.3,,1.14,us,usp000debc,2022-05-02T17:45:23.937Z,Turkey-Iraq border region,earthquake,,4.2,,,reviewed,us,hrv
+2005-01-25T11:39:20.910Z,33.388,45.872,45.2,5,mwc,152,89.1,,0.84,us,usp000deag,2016-11-10T00:59:19.826Z,"40 km NW of Mehr?n, Iran",earthquake,,5.1,,,reviewed,us,hrv
+2005-01-23T22:36:05.530Z,35.796,29.641,10,5.8,mwb,524,47.7,,1.34,us,usp000de4y,2022-07-14T18:31:53.704Z,"45 km S of Ka?, Turkey",earthquake,,,,,reviewed,us,us
+2005-01-11T04:36:00.970Z,36.917,27.867,34.9,5.1,mwc,467,24.7,,1.07,us,usp000dd1a,2022-07-14T18:47:05.952Z,"25 km NE of Datça, Turkey",earthquake,,4.1,,,reviewed,us,hrv
+2005-01-10T23:50:25.680Z,37.018,27.919,10,5,mb,50,47.6,,0.93,us,usp000dd0j,2022-07-14T18:48:46.917Z,"32 km ESE of Güvercinlik, Turkey",earthquake,,,,18,reviewed,us,us
+2005-01-10T23:48:50.020Z,37.017,27.804,15.9,5.5,mwc,344,23.2,,,us,usp000dd0h,2022-05-02T17:42:31.313Z,"23 km SE of Güvercinlik, Turkey",earthquake,,,,,reviewed,isk,hrv
+2005-01-10T18:47:30.180Z,37.103,54.574,31.9,5.4,mwc,408,45.1,,0.95,us,usp000dd01,2022-07-14T18:50:28.492Z,"31 km NNE of Gorg?n, Iran",earthquake,,,,,reviewed,us,hrv
+2004-12-20T23:02:12.410Z,37.042,28.206,5,5.4,mwc,508,24.9,,,us,usp000db47,2022-05-02T17:38:11.766Z,"19 km WSW of Ula, Turkey",earthquake,,,,,reviewed,isk,hrv
+2004-11-25T06:21:19.780Z,43.167,15.364,21.9,5.3,mwc,499,8.6,,1.11,us,usp000d951,2022-07-14T19:27:50.525Z,"60 km WNW of Komiža, Croatia",earthquake,,,,,reviewed,us,hrv
+2004-11-23T02:26:16.350Z,40.324,20.629,15.4,5.5,mwc,507,30.8,,1.13,us,usp000d905,2022-05-02T17:34:10.673Z,"4 km WSW of Ersekë, Albania",earthquake,,,,,reviewed,us,hrv
+2004-11-22T04:01:30.440Z,33.297,47.977,36.2,5,mwc,268,62.5,,1.07,us,usp000d8y4,2022-05-02T17:33:58.277Z,"22 km SSW of Vas??n, Iran",earthquake,,,,,reviewed,us,hrv
+2004-11-21T21:37:24.230Z,33.301,47.983,30.1,5.2,mwc,211,49.2,,0.94,us,usp000d8xn,2022-05-02T17:33:51.499Z,"21 km SSW of Vas??n, Iran",earthquake,,,,,reviewed,us,hrv
+2004-11-04T06:22:39.400Z,35.945,23.115,74.4,5.3,mwb,599,45.5,,1.1,us,usp000d7nu,2021-10-20T18:08:08.747Z,"25 km SSE of Kýthira, Greece",earthquake,,,,,reviewed,us,us
+2004-10-27T20:34:36.810Z,45.787,26.622,95.8,5.9,mwb,681,9.8,,0.94,us,usp000d778,2022-07-14T19:58:16.889Z,"7 km W of Paltin, Romania",earthquake,,,,,reviewed,us,us
+2004-10-07T21:46:20.300Z,37.125,54.477,34.6,5.6,mwb,526,45.2,,0.84,us,usp000d5z5,2022-05-02T17:29:52.814Z,"31 km N of Gorg?n, Iran",earthquake,,,,,reviewed,us,us
+2004-10-07T01:05:12.890Z,36.429,26.796,128.9,5.5,mwc,706,29,,1.01,us,usp000d5xb,2022-05-02T17:29:38.313Z,"36 km SW of Mandráki, Greece",earthquake,,,,,reviewed,us,hrv
+2004-08-11T15:48:26.820Z,38.377,39.261,7.4,5.7,mwc,487,58,,1.1,us,usp000d1yj,2022-05-02T17:22:37.538Z,"8 km SSW of Sivrice, Turkey",earthquake,,4.9,,,reviewed,us,hrv
+2004-08-04T14:18:50.160Z,36.832,27.827,10,5.3,mwc,340,23.1,,1.07,us,usp000d1fa,2022-05-02T17:21:38.949Z,"16 km NE of Datça, Turkey",earthquake,,,,,reviewed,us,hrv
+2004-08-04T04:19:48.370Z,36.843,27.85,10,5.2,mwc,440,22.1,,0.94,us,usp000d1ea,2022-05-02T17:21:37.859Z,"18 km NE of Datça, Turkey",earthquake,,,,,reviewed,us,hrv
+2004-08-04T03:01:07.570Z,36.833,27.815,10,5.6,mwc,412,19.7,,1.3,us,usp000d1e2,2022-05-02T17:21:36.382Z,"15 km NE of Datça, Turkey",earthquake,,,,,reviewed,us,hrv
+2004-08-03T13:11:30.300Z,37.02,27.72,2,5.2,mwc,248,27.6,,,us,usp000d1cq,2022-05-02T17:21:30.483Z,"17 km SE of Güvercinlik, Turkey",earthquake,,,,,reviewed,ath,hrv
+2004-07-12T13:04:07.160Z,46.296,13.641,7.7,5.2,mwc,476,6.5,,1,us,usp000d00p,2022-05-02T17:17:25.554Z,"7 km NE of Kobarid, Slovenia",earthquake,,2.4,,,reviewed,us,hrv
+2004-07-01T22:30:09.320Z,39.766,43.979,5,5.1,mwc,422,63.3,,1.09,us,usp000czcr,2022-05-02T17:16:48.179Z,"18 km SSW of I?d?r, Turkey",earthquake,,,,,reviewed,us,hrv
+2004-06-15T12:02:37.760Z,40.439,25.871,12,5.2,mwc,335,40.1,,,us,usp000cxyq,2022-05-02T17:14:03.830Z,"26 km N of Gökçeada, Turkey",earthquake,,,,,reviewed,isk,hrv
+2004-05-28T12:38:44.470Z,36.29,51.61,17,6.3,mwc,732,21.5,,0.92,us,usp000cwf9,2022-05-02T17:12:45.251Z,"41 km SSE of Nowshahr, Iran",earthquake,,,,,reviewed,us,hrv
+2004-05-23T15:19:07.960Z,43.406,17.447,10,5,mwc,465,13,,1.18,us,usp000cw01,2022-05-02T17:12:32.654Z,"3 km WNW of Ko?erin, Bosnia and Herzegovina",earthquake,,,,,reviewed,us,hrv
+2004-05-05T13:39:43.860Z,38.507,14.814,228.9,5.5,mwb,651,21.2,,1.22,us,usp000cu7w,2022-05-02T17:10:35.384Z,"5 km S of Leni, Italy",earthquake,,,,,reviewed,us,us
+2004-04-07T01:32:30.470Z,40.666,20.375,68.3,5,mwc,367,23.6,,1.14,us,usp000crw3,2016-11-10T00:30:54.494Z,"21 km NE of Çorovodë, Albania",earthquake,,,,,reviewed,us,hrv
+2004-03-28T03:51:10.050Z,39.847,40.874,5,5.6,mwc,509,38,,,us,usp000cr2z,2022-05-02T17:07:14.915Z,"17 km ESE of A?kale, Turkey",earthquake,,,,,reviewed,isk,hrv
+2004-03-25T19:30:49.040Z,39.93,40.812,10,5.6,mwb,237,58.4,,1.11,us,usp000cqvt,2022-05-02T17:06:59.431Z,"10 km E of A?kale, Turkey",earthquake,,,,,reviewed,us,us
+2004-03-17T05:21:00.800Z,34.589,23.326,24.5,6.1,mwb,656,46.8,,1.01,us,usp000cq54,2022-05-02T17:06:28.673Z,"74 km WSW of Kastrí, Greece",earthquake,,,,,reviewed,us,us
+2004-03-01T00:35:58.050Z,37.136,22.116,9.4,5.6,mwb,522,40.1,,1.22,us,usp000cnsj,2022-05-02T17:04:27.855Z,"6 km ESE of Arfará, Greece",earthquake,,3.7,,,reviewed,us,us
+2004-02-11T08:15:03.830Z,31.675,35.551,26.7,5.3,mwc,386,99.7,,0.89,us,usp000ckyy,2022-05-02T17:02:35.998Z,"21 km SE of Mi?pé Yeri?o, Israel",earthquake,,,,,reviewed,us,hrv
+2004-02-07T21:17:24.200Z,36.04,26.91,25,5.1,mwc,423,35.3,,,us,usp000ckns,2022-05-02T17:02:11.231Z,"65 km NNW of Karpathos, Greece",earthquake,,,,,reviewed,ath,hrv
+2003-12-11T16:28:17.350Z,31.953,49.209,33,5,mb,168,56.8,,0.95,us,usp000cf1c,2022-05-02T15:54:43.109Z,"9 km WNW of Masjed Soleym?n, Iran",earthquake,,,,75,reviewed,us,us
+2003-11-21T10:34:36.980Z,31.401,59.427,33,5,mwc,69,55.6,,0.86,us,usp000cdjw,2022-05-02T16:54:20.670Z,"163 km S of B?rjand, Iran",earthquake,,,,,reviewed,us,hrv
+2003-11-18T23:21:14.400Z,31.02,51.287,33,5.1,mb,300,89.9,,0.95,us,usp000cdc0,2022-05-02T16:54:11.083Z,"48 km NW of Yasuj, Iran",earthquake,,,,94,reviewed,us,us
+2003-11-16T07:22:49.700Z,38.27,20.34,8,5.2,mwc,343,51.4,,,us,usp000ccyv,2022-05-02T16:54:03.937Z,"11 km NW of Lixoúri, Greece",earthquake,,,,,reviewed,ath,hrv
+2003-10-17T12:57:07.720Z,35.94,22.161,33.9,5.3,mb,469,52.1,,1.23,us,usp000cam6,2022-05-02T16:50:49.895Z,"78 km WSW of Kýthira, Greece",earthquake,,3.1,,164,reviewed,us,us
+2003-09-13T13:46:14.340Z,36.629,26.918,155,5.3,mwc,443,39.8,,1.05,us,usp000c7e7,2016-11-09T23:28:25.270Z,"13 km SSW of Kéfalos, Greece",earthquake,,2,,,reviewed,us,hrv
+2003-08-14T16:18:02.450Z,38.826,20.573,10,5.5,mwc,391,31.5,,1.3,us,usp000c4vq,2022-05-02T15:53:27.401Z,"11 km W of Lefkáda, Greece",earthquake,,,,,reviewed,us,hrv
+2003-08-14T12:18:14.180Z,38.896,20.61,10,5.2,mwc,287,53.7,,1.41,us,usp000c4v8,2022-05-02T16:40:46.527Z,"10 km NW of Lefkáda, Greece",earthquake,,,,,reviewed,us,hrv
+2003-08-14T05:14:54.760Z,39.16,20.605,10,6.3,mwc,572,31.9,,1.08,us,usp000c4tt,2022-05-02T16:40:34.239Z,"8 km S of Kanaláki, Greece",earthquake,,,,,reviewed,us,hrv
+2003-07-26T08:36:49.170Z,38.019,28.927,10,5.4,mwc,463,19.9,,1.02,us,usp000c3da,2022-05-02T16:39:32.155Z,"8 km ESE of Buldan, Turkey",earthquake,,,,,reviewed,us,hrv
+2003-07-23T04:56:02.960Z,38.172,28.853,5,5.4,mwc,410,14,,,us,usp000c33z,2022-05-02T16:39:21.925Z,"14 km N of Buldan, Turkey",earthquake,,,,,reviewed,isk,hrv
+2003-07-13T01:48:21.990Z,38.288,38.963,10,5.6,mwb,513,69.5,,1.06,us,usp000c2bg,2022-05-02T16:38:59.731Z,"6 km WSW of Do?anyol, Turkey",earthquake,,,,,reviewed,us,us
+2003-07-06T20:10:16.450Z,40.421,26.128,17,5.3,mwc,351,13,,,us,usp000c1u9,2022-05-02T16:38:37.927Z,"30 km NE of Gökçeada, Turkey",earthquake,,,,,reviewed,the,hrv
+2003-07-06T19:10:28.160Z,40.445,26.024,17.1,5.7,mwb,439,15.2,,1.02,us,usp000c1tz,2022-05-02T16:38:31.712Z,"28 km NNE of Gökçeada, Turkey",earthquake,,1.6,,,reviewed,us,us
+2003-07-03T14:59:32.280Z,35.476,60.784,40.8,5.2,mwc,228,45.9,,0.88,us,usp000c1jh,2022-05-02T16:38:19.364Z,"29 km NNE of Torbat-e J?m, Iran",earthquake,,4.8,,,reviewed,us,hrv
+2003-06-09T07:06:39.330Z,39.893,22.309,17.8,5.2,mwc,347,43.6,,1.23,us,usp000bzf2,2022-05-02T16:37:07.028Z,"7 km E of Tsarítsani, Greece",earthquake,,,,,reviewed,us,hrv
+2003-05-03T11:22:40.630Z,36.884,31.536,135.3,5.5,mwc,447,50.7,,0.94,us,usp000bwh3,2020-09-18T19:23:04.842Z,"13 km NE of Manavgat, Turkey",earthquake,,1.7,,,reviewed,us,hrv
+2003-05-01T00:27:04.700Z,39.007,40.464,10,6.4,mwb,504,30.9,,1.09,us,usp000bwbc,2022-05-02T16:31:10.015Z,"13 km N of Bingöl, Turkey",earthquake,,,,,reviewed,us,us
+2003-04-29T01:51:20.200Z,36.83,21.72,67,5.1,mwc,496,65.4,,,us,usp000bw61,2016-11-09T22:24:29.766Z,"1 km NE of Methóni, Greece",earthquake,,,,,reviewed,ath,hrv
+2003-04-17T22:34:24.590Z,38.158,27,10,5.2,mwc,352,17.4,,1.17,us,usp000bvdg,2022-05-02T16:30:20.191Z,"14 km ESE of Seferihisar, Turkey",earthquake,,,,,reviewed,us,hrv
+2003-04-10T00:40:15.110Z,38.221,26.958,10,5.8,mwb,471,15.1,,1.12,us,usp000buu9,2022-05-02T16:29:21.054Z,"10 km ENE of Seferihisar, Turkey",earthquake,,,,,reviewed,us,us
+2003-03-29T17:42:15.700Z,43.109,15.464,10,5.5,mwc,525,15.2,,,us,usp000btsh,2022-05-02T16:28:31.245Z,"51 km W of Komiža, Croatia",earthquake,,,,,reviewed,rom,hrv
+2003-03-27T16:10:36.410Z,43.15,15.335,10,5,mwc,313,14.3,,1.18,us,usp000btn0,2016-11-09T22:10:26.742Z,"62 km W of Komiža, Croatia",earthquake,,,,,reviewed,us,hrv
+2003-01-27T05:26:23.040Z,39.5,39.878,10,6.1,mwc,384,,,1.14,us,usp000bpa1,2022-05-02T16:24:21.400Z,"2 km NW of Pulumer, Turkey",earthquake,,,,,reviewed,us,hrv
+2002-12-24T17:03:02.940Z,34.594,47.454,33,5.2,mwc,258,,,1.1,us,usp000bmbe,2022-05-02T16:21:00.895Z,"24 km SSW of Sonqor, Iran",earthquake,,,,,reviewed,us,hrv
+2002-12-09T09:35:04.890Z,37.869,19.973,10,5.2,mwc,199,,,1.31,us,usp000bkd6,2022-05-02T16:18:54.871Z,"54 km SW of Lixoúri, Greece",earthquake,,,,,reviewed,us,hrv
+2002-12-02T04:58:55.190Z,37.747,21.087,10,5.7,mwc,234,,,1.21,us,usp000bjwy,2022-05-02T16:18:39.595Z,"11 km S of Arkoúdi, Greece",earthquake,,,,,reviewed,us,hrv
+2002-11-30T08:15:46.800Z,45.726,26.568,162.5,5,mb,155,,,0.98,us,usp000bjry,2014-11-07T01:17:12.502Z,"10 km WNW of Nereju Mic, Romania",earthquake,,,,62,reviewed,us,us
+2002-11-09T02:18:11.540Z,45.003,37.768,10,5.5,mwc,288,,,1.09,us,usp000bh4m,2022-05-02T16:16:07.325Z,"10 km WSW of Kiyevskoye, Russia",earthquake,,,,,reviewed,us,hrv
+2002-11-02T10:57:43.170Z,44.581,12.165,10,5,ml,162,,,1.2,us,usp000bfwh,2014-11-07T01:16:56.229Z,"4 km N of Sant'Alberto, Italy",earthquake,,,,,reviewed,us,zamg
+2002-11-01T15:09:00.810Z,41.726,14.875,10,5.8,mwb,454,,,1.35,us,usp000bftq,2022-05-02T16:14:44.492Z,"2 km ESE of Casacalenda, Italy",earthquake,,,,,reviewed,us,us
+2002-10-31T10:32:58.770Z,41.789,14.872,10,5.9,mwb,471,,,1.25,us,usp000bfqg,2022-05-02T16:13:21.296Z,"4 km WSW of Larino, Italy",earthquake,,,,,reviewed,us,us
+2002-10-19T15:57:13.880Z,39.039,54.913,33,5.2,mwc,245,,,0.93,us,usp000bevf,2022-05-02T16:12:10.134Z,"33 km ESE of Gumdag, Turkmenistan",earthquake,,,,,reviewed,us,hrv
+2002-10-16T09:20:49.830Z,31.455,56.469,33,5.3,mwc,49,,,1.18,us,usp000bep0,2022-05-02T16:12:01.918Z,"36 km N of Shahrak-e P?bed?n?, Iran",earthquake,,,,,reviewed,us,hrv
+2002-10-12T05:58:50.110Z,34.772,26.371,10,5.4,mwc,362,,,1.23,us,usp000bebt,2022-05-02T16:11:44.367Z,"48 km SSE of Palekastro, Greece",earthquake,,,,,reviewed,us,hrv
+2002-09-27T06:10:44.900Z,38.437,13.695,5,5.3,mwc,294,,,,us,usp000bd72,2022-05-02T16:09:51.507Z,"39 km NNE of Santa Flavia, Italy",earthquake,,,,,reviewed,rom,hrv
+2002-09-25T22:28:11.920Z,31.995,49.329,10,5.6,mwc,417,,,0.98,us,usp000bd44,2022-05-02T16:09:10.640Z,"6 km NNE of Masjed Soleym?n, Iran",earthquake,,,,,reviewed,us,hrv
+2002-09-06T01:21:28.600Z,38.381,13.701,5,6,mwc,528,,,,us,usp000bbb2,2022-05-02T16:07:26.244Z,"34 km NNE of Santa Flavia, Italy",earthquake,,,,,reviewed,rom,hrv
+2002-09-02T01:00:03.270Z,35.701,48.838,10,5.2,mwc,249,,,1.03,us,usp000bb34,2022-05-02T16:07:34.494Z,"60 km SW of Abhar, Iran",earthquake,,,,,reviewed,us,hrv
+2002-07-28T17:16:31.060Z,37.932,20.692,22.2,5.3,mwc,250,,,1.12,us,usp000b8y2,2022-05-02T16:04:30.748Z,"12 km NNW of Katastárion, Greece",earthquake,,3.9,,,reviewed,us,hrv
+2002-06-22T02:58:21.300Z,35.626,49.047,10,6.5,mwc,555,,,1.11,us,usp000b6pk,2022-05-02T16:01:41.789Z,"59 km SSW of Abhar, Iran",earthquake,,,,,reviewed,us,hrv
+2002-06-18T03:19:24.250Z,33.326,45.913,33,5.3,mwc,249,,,1,us,usp000b6d2,2022-05-02T16:01:34.091Z,"32 km NW of Mehr?n, Iran",earthquake,,,,,reviewed,us,hrv
+2002-06-06T22:35:41.980Z,35.648,26.183,87.4,5.2,mwc,161,,,1.45,us,usp000b5nw,2016-11-09T22:41:37.055Z,"49 km N of Sitia, Greece",earthquake,,,,,reviewed,us,hrv
+2002-05-21T20:53:29.700Z,36.627,24.274,97.1,5.9,mwc,353,,,1.21,us,usp000b4ra,2022-05-02T15:58:44.840Z,"18 km SW of Adámas, Greece",earthquake,,,,,reviewed,us,hrv
+2002-04-24T19:48:07.120Z,34.642,47.4,33,5.4,mwc,261,,,1.13,us,usp000b33c,2022-05-02T15:51:28.900Z,"23 km SW of Sonqor, Iran",earthquake,,,,,reviewed,us,hrv
+2002-04-24T10:51:50.930Z,42.436,21.466,10,5.7,mwc,522,,,1.1,us,usp000b324,2022-05-02T15:57:02.655Z,"2 km S of Gjilan, Kosovo",earthquake,,,,,reviewed,us,hrv
+2002-04-19T13:46:49.770Z,36.567,49.81,33,5.2,mwc,233,,,0.89,us,usp000b2s5,2022-05-02T15:50:30.140Z,"37 km NNW of Qazvin, Iran",earthquake,,,,,reviewed,us,hrv
+2002-04-17T06:42:54.300Z,39.7,16.843,5,5.3,mwc,296,,,,us,usp000b2jt,2022-05-02T15:50:20.696Z,"12 km NNE of Mirto, Italy",earthquake,,,,,reviewed,rom,hrv
+2002-04-05T18:40:19.190Z,32.057,55.973,33,5.2,mwc,205,,,0.91,us,usp000b1t8,2022-05-02T15:56:55.640Z,"73 km NE of B?fq, Iran",earthquake,,,,,reviewed,us,hrv
+2002-02-11T16:18:33.720Z,40.102,50.211,54.2,5,mwc,124,,,0.85,us,usp000ay8f,2022-05-02T15:44:18.230Z,"29 km S of Türkan, Azerbaijan",earthquake,,,,,reviewed,us,hrv
+2002-02-03T11:39:55.380Z,38.551,31.181,10,5.3,mwc,314,,,1.21,us,usp000axpx,2022-05-02T15:26:10.688Z,"4 km WNW of Sultanda??, Turkey",earthquake,,,,,reviewed,us,hrv
+2002-02-03T09:26:43.350Z,38.632,30.902,10,6,mwb,450,,,0.91,us,usp000axpg,2022-05-02T15:44:05.575Z,"11 km WNW of Çay, Turkey",earthquake,,,,,reviewed,us,us
+2002-02-03T07:14:36.420Z,38.701,30.872,10,5.5,mb,56,,,0.95,us,usp000axp8,2022-05-02T15:51:15.229Z,"11 km ENE of I??klar, Turkey",earthquake,,,,29,reviewed,us,us
+2002-02-03T07:11:28.410Z,38.573,31.271,5,6.5,mwc,482,,,,us,usp000axp7,2022-05-02T15:43:44.796Z,"5 km NE of Sultanda??, Turkey",earthquake,,,,,reviewed,isk,hrv
+2002-01-22T04:53:52.650Z,35.79,26.617,88,6.2,mwc,390,,,0.95,us,usp000awya,2022-05-02T15:42:26.486Z,"49 km NW of Fry, Greece",earthquake,,,,,reviewed,us,hrv
+2001-11-26T05:03:21.010Z,34.82,24.28,33,5.3,mwc,402,,,1.32,us,usp000atge,2022-04-29T19:41:55.841Z,"17 km E of Kastrí, Greece",earthquake,,,,,reviewed,us,hrv
+2001-10-31T12:33:52.810Z,37.249,36.136,10,5.1,mb,271,,,0.93,us,usp000arzg,2022-04-29T19:39:27.092Z,"14 km SSE of Kadirli, Turkey",earthquake,,,,125,reviewed,us,us
+2001-09-16T02:00:47.390Z,37.244,21.873,10,5.5,mwc,293,,,1.01,us,usp000ap8j,2022-04-29T19:34:00.693Z,"6 km SE of Kopanáki, Greece",earthquake,,,,,reviewed,us,hrv
+2001-09-01T22:38:16.830Z,32.726,47.68,14.1,5,mwc,204,,,0.96,us,usp000anes,2022-04-29T19:30:41.853Z,"38 km SE of ?bd?n?n, Iran",earthquake,,,,,reviewed,us,hrv
+2001-08-26T00:41:13.170Z,40.951,31.573,7.8,5,mb,332,,,,us,usp000an1e,2022-04-29T19:29:59.600Z,"24 km N of Bolu, Turkey",earthquake,,,,143,reviewed,isk,us
+2001-07-30T15:24:56.740Z,39.091,24.044,10,5,mwc,270,,,1.24,us,usp000akhg,2022-04-29T19:27:36.418Z,"16 km ESE of Patitírion, Greece",earthquake,,,,,reviewed,us,hrv
+2001-07-26T00:21:36.920Z,39.059,24.244,10,6.5,mwc,483,,,1.04,us,usp000ak5s,2022-04-29T19:26:49.061Z,"32 km WNW of Skýros, Greece",earthquake,,,,,reviewed,us,hrv
+2001-07-20T05:09:39.670Z,45.749,26.734,128.6,5.3,mwc,315,,,1.12,us,usp000ajvs,2016-11-09T23:01:37.621Z,"2 km W of Spulber, Romania",earthquake,,,,,reviewed,us,hrv
+2001-07-10T21:42:08.840Z,39.832,41.623,33,5.4,mwc,269,,,1.06,us,usp000ajbh,2022-04-29T19:25:48.066Z,"16 km SSW of Pasinler, Turkey",earthquake,,,,,reviewed,us,hrv
+2001-07-01T01:48:59.080Z,47.75,16.137,10,5.1,md,61,,,0.72,us,usp000ahsf,2014-11-07T01:13:11.665Z,"1 km NNW of Breitenau, Austria",earthquake,,,,,reviewed,us,vie
+2001-06-25T13:28:46.510Z,37.238,36.206,5,5.5,mwc,288,,,1.29,us,usp000ahe3,2022-04-29T19:24:30.874Z,"17 km SSE of Kadirli, Turkey",earthquake,,,,,reviewed,us,hrv
+2001-06-23T06:52:42.960Z,35.55,28.157,50.1,5.7,mwc,416,,,1.14,us,usp000ah3s,2022-04-29T19:23:22.360Z,"61 km SSE of Lárdos, Greece",earthquake,,2.6,,,reviewed,us,hrv
+2001-06-10T13:11:04.230Z,38.582,25.613,33,5.6,mwc,333,,,1.28,us,usp000agbw,2022-04-29T19:21:33.510Z,"6 km NE of Psará, Greece",earthquake,,,,,reviewed,us,hrv
+2001-06-10T01:52:08.010Z,39.873,53.89,34.1,5.4,mwc,379,,,0.99,us,usp000agb7,2022-04-29T19:21:32.410Z,"57 km NW of Balkanabat, Turkmenistan",earthquake,,,,,reviewed,us,hrv
+2001-06-05T15:33:29.770Z,42.472,48.634,60.3,5,mb,258,,,1.2,us,usp000ag40,2022-04-29T19:21:23.645Z,"53 km NNE of Derbent, Russia",earthquake,,5.9,,119,reviewed,us,us
+2001-05-29T04:43:57.940Z,35.407,27.779,20.7,5.2,mwc,327,,,1.09,us,usp000afqc,2022-04-29T19:20:41.027Z,"52 km ESE of Karpathos, Greece",earthquake,,3.5,,,reviewed,us,hrv
+2001-05-24T17:34:01.020Z,45.688,26.416,141.6,5.2,mwc,333,,,1.08,us,usp000affk,2016-11-09T22:35:53.741Z,"14 km SE of Comand?u, Romania",earthquake,,,,,reviewed,us,hrv
+2001-05-17T11:43:57.860Z,38.958,15.526,239.5,5.2,mwr,397,,,1.02,us,usp000af26,2014-11-07T01:12:48.212Z,"43 km NW of Santa Domenica, Italy",earthquake,,1.7,,,reviewed,us,csem
+2001-05-01T06:00:56.390Z,35.696,27.504,33,5.2,mwc,362,,,1.33,us,usp000ae8w,2022-04-29T19:10:31.028Z,"Dodecanese Islands, Greece",earthquake,,,,,reviewed,us,hrv
+2001-04-09T17:38:40.080Z,40.082,20.406,52.5,5.1,mwc,297,,,1.39,us,usp000acwb,2022-04-29T19:12:39.430Z,"13 km S of Gjinkar, Albania",earthquake,,3.1,,,reviewed,us,hrv
+2001-04-03T17:36:34.220Z,32.472,47.985,33,5.2,mwc,259,,,1.01,us,usp000acgs,2022-04-29T19:10:10.472Z,"39 km NW of Sh?sh, Iran",earthquake,,,,,reviewed,us,hrv
+2001-03-23T05:24:11.940Z,32.951,46.625,33,5.5,mwb,231,,,1.24,us,usp000abwm,2022-04-29T19:12:58.855Z,"47 km ESE of Mehr?n, Iran",earthquake,,,,,reviewed,us,us
+2001-01-07T06:49:00.630Z,40.171,50.143,33,5.2,mwc,123,,,0.87,us,usp000a78k,2022-04-29T19:03:58.853Z,"22 km SSW of Türkan, Azerbaijan",earthquake,,,,,reviewed,us,hrv
+2000-12-15T16:44:47.660Z,38.457,31.351,10,6,mwc,174,,,1.24,us,usp000a64f,2022-04-29T19:01:28.396Z,"12 km NNW of Ak?ehir, Turkey",earthquake,,,,,reviewed,us,hrv
+2000-12-15T16:44:43.440Z,38.541,31.207,10,5,mb,161,,,1.26,us,usp000a64e,2014-11-07T01:11:44.081Z,"2 km WNW of Sultanda??, Turkey",earthquake,,,,49,reviewed,us,us
+2000-12-06T17:11:06.400Z,39.566,54.799,30,7,mwc,495,,,0.9,us,usp000a5m7,2022-04-29T19:00:52.062Z,"37 km E of Balkanabat, Turkmenistan",earthquake,,,,,reviewed,us,hrv
+2000-11-29T10:44:59.080Z,39.856,50.209,33,5,mb,17,,,1.56,us,usp000a565,2014-11-07T01:11:35.229Z,"56 km S of Türkan, Azerbaijan",earthquake,,,,4,reviewed,us,us
+2000-11-25T18:10:47.390Z,40.167,49.954,33,6.5,mwc,268,,,1.02,us,usp000a4xv,2022-04-29T18:59:55.829Z,"23 km SSE of Badamdar, Azerbaijan",earthquake,,,,,reviewed,us,hrv
+2000-11-25T18:09:11.420Z,40.245,49.946,50.4,6.8,mwc,446,,,1.03,us,usp000a4xu,2022-04-29T19:46:29.848Z,"15 km SSE of Baku, Azerbaijan",earthquake,,2.7,,,reviewed,us,hrv
+2000-11-15T15:05:38.170Z,38.397,42.922,65.3,5.6,mwb,292,,,1.08,us,usp000a3p3,2022-04-29T18:57:46.635Z,"19 km NW of Geva?, Turkey",earthquake,,,,,reviewed,us,us
+2000-10-23T06:54:49.580Z,31.583,59.847,33,5.3,mwc,218,,,1.01,us,usp000a28r,2022-04-29T18:55:06.059Z,"154 km SSE of B?rjand, Iran",earthquake,,,,,reviewed,us,hrv
+2000-09-19T15:19:12.690Z,38.301,57.479,33,5.2,mwc,78,,,1.36,us,usp000a0hf,2022-04-29T18:53:12.863Z,"15 km SSE of Baharly, Turkmenistan",earthquake,,,,,reviewed,us,hrv
+2000-08-23T13:41:28.140Z,40.68,30.72,15.3,5.3,mwc,352,,,,us,usp0009z1g,2022-04-29T18:51:00.127Z,"8 km E of Akyaz?, Turkey",earthquake,,,,,reviewed,isk,hrv
+2000-08-22T16:55:13.700Z,38.117,57.376,10,5.9,mwb,257,,,1.06,us,usp0009yz6,2022-04-29T18:50:42.392Z,"35 km S of Baharly, Turkmenistan",earthquake,,,,,reviewed,us,us
+2000-07-11T10:56:03.900Z,47.965,16.36,10,5,ml,106,,,1.18,us,usp0009w84,2014-11-07T01:10:35.266Z,"3 km ESE of Oberwaltersdorf, Austria",earthquake,,,,,reviewed,us,cll
+2000-07-11T02:49:47.600Z,48.013,16.419,10,5.3,ml,182,,,1.26,us,usp0009w6r,2020-09-15T21:29:25.635Z,"2 km W of Moosbrunn, Austria",earthquake,,,,,reviewed,us,brg
+2000-06-23T06:15:12.470Z,30.162,51.649,33,5.2,mwc,115,,,1.18,us,usp0009v0b,2022-04-29T19:47:01.066Z,"13 km ENE of N?r?b?d, Iran",earthquake,,,,,reviewed,us,hrv
+2000-06-15T21:30:29.030Z,34.441,20.182,10,5.2,mwc,229,,,1.09,us,usp0009uny,2016-11-09T22:45:48.204Z,"214 km N of T?krah, Libya",earthquake,,,,,reviewed,us,hrv
+2000-06-13T01:43:14.430Z,35.146,27.125,10,5.4,mwc,261,,,1.32,us,usp0009ugd,2022-04-29T18:40:46.084Z,"35 km SSE of Fry, Greece",earthquake,,,,,reviewed,us,hrv
+2000-06-06T02:41:49.800Z,40.693,32.992,10,6,mwc,418,,,1.04,us,usp0009u3d,2022-04-29T18:39:52.357Z,"12 km NW of Orta, Turkey",earthquake,,,,,reviewed,us,hrv
+2000-05-26T01:28:22.540Z,38.922,20.64,0,5.6,mwc,,,,,us,usp0009tg5,2022-04-29T18:39:12.264Z,"10 km WSW of Préveza, Greece",earthquake,,,,,reviewed,the,hrv
+2000-05-24T10:01:44.840Z,35.916,22.1,33,5.2,mwc,,,,1.4,us,usp0009tds,2016-11-09T22:35:51.578Z,"84 km WSW of Kýthira, Greece",earthquake,,,,,reviewed,us,hrv
+2000-05-24T05:40:37.740Z,36.042,22.012,33,5.7,mwc,,,,1.24,us,usp0009tde,2022-04-29T18:39:08.002Z,"83 km S of Koróni, Greece",earthquake,,,,,reviewed,us,hrv
+2000-05-10T16:52:09.810Z,44.315,12.002,10,5.1,mwc,,,,1.22,us,usp0009sr1,2022-04-29T18:38:39.863Z,"7 km SE of Granarolo, Italy",earthquake,,,,,reviewed,us,hrv
+2000-04-21T12:23:10.510Z,37.842,29.328,33,5.5,mwc,,,,1.21,us,usp0009rnd,2022-04-29T18:37:24.627Z,"10 km NNE of Honaz, Turkey",earthquake,,,,,reviewed,us,hrv
+2000-04-06T00:10:38.780Z,45.743,26.58,132.6,5.2,mwc,,,,1.03,us,usp0009qvs,2016-11-09T22:14:29.863Z,"9 km WNW of Nereju Mic, Romania",earthquake,,,,,reviewed,us,hrv
+2000-04-05T04:36:58.800Z,34.22,25.69,38,5.5,mwc,,,,,us,usp0009que,2022-04-29T18:36:29.619Z,"87 km S of Néa Anatolí, Greece",earthquake,,,,,reviewed,ath,hrv
+2000-03-21T14:07:40.820Z,39.949,48.23,59.7,5.2,mwc,,,,1.01,us,usp0009q00,2022-04-29T18:35:01.392Z,"12 km W of Saatl?, Azerbaijan",earthquake,,,,,reviewed,us,hrv
+2000-03-10T22:01:45.970Z,34.356,26.029,10,5.3,mwc,,,,0.98,us,usp0009phq,2016-11-09T22:02:47.014Z,"77 km SSE of Ierápetra, Greece",earthquake,,,,,reviewed,us,hrv
+2000-02-26T08:18:37.690Z,37.304,44.76,33,5.2,ms,,,,0.92,us,usp0009nzq,2014-11-07T01:09:33.908Z,"16 km E of ?emdinli, Turkey",earthquake,,,,1,reviewed,us,us
+2000-02-22T11:55:25.630Z,34.598,25.599,33,5.3,mwc,,,,1.19,us,usp0009nu4,2022-04-29T18:33:18.574Z,"45 km S of Néa Anatolí, Greece",earthquake,,,,,reviewed,us,hrv
+2000-02-02T22:58:01.550Z,35.288,58.218,33,5.3,mwc,,,,0.95,us,usp0009mz6,2022-04-29T18:30:51.329Z,"22 km E of Bardaskan, Iran",earthquake,,,,,reviewed,us,hrv
+2000-01-26T23:00:19.940Z,40.021,52.901,33,5.3,mwc,,,,0.83,us,usp0009mqc,2022-04-29T18:30:16.740Z,"4 km W of Türkmenba?y, Turkmenistan",earthquake,,,,,reviewed,us,hrv


### PR DESCRIPTION
Filter down earthquake data by keeping only earthquakes located near turkey. I.e. Longitude between 12 and 64,
Latitude between 30 and 50